### PR TITLE
Linux port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build-linux/
 /build-dbg/
 /build-asan/
+/build-win32/
 /lib/*.exp
 /lib/*.lib
 /src/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 /build/**
 /release
+
+# Linux (CMake) build trees
+/build-linux/
+/build-dbg/
+/build-asan/
 /lib/*.exp
 /lib/*.lib
 /src/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@
 /src/WinSnd/debug
 /src/WinSnd/release
 *.user
+
+# Screenshots
+/Bildschirmfoto_*.png
+/Screenshot_*.png

--- a/BUILDING-linux.md
+++ b/BUILDING-linux.md
@@ -1,0 +1,101 @@
+# Building Heretic2R on Linux
+
+Heretic2R was originally a Windows/MSVC-only project. This documents the Linux port:
+a CMake build that produces the same module layout as the MSVC solution, as ELF
+shared objects loaded at runtime via `dlopen()`.
+
+> Status: **compiles and links** (engine, launcher, and all game-side modules).
+> Runtime has not yet been validated end-to-end and still needs Heretic II game data
+> plus a real display/audio backend.
+
+## Prerequisites
+
+- GCC (tested with 14.2) and CMake ≥ 3.16
+- OpenGL development headers (`libgl1-mesa-dev` / `libglu1-mesa-dev`)
+- **SDL3 3.4.2** — must match the headers bundled in `include/SDL3/`. The distro package
+  (3.2.x) is too old. Build it from source:
+
+  ```sh
+  git clone --depth 1 --branch release-3.4.2 https://github.com/libsdl-org/SDL.git
+  cd SDL
+  # -DSDL_X11_XTEST=OFF: this machine lacks the XTest extension dev headers.
+  # Drop that flag if you have them (libxtst-dev).
+  cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DSDL_SHARED=ON -DSDL_STATIC=OFF \
+        -DSDL_TEST_LIBRARY=OFF -DSDL_X11_XTEST=OFF -DCMAKE_INSTALL_PREFIX=/path/to/sdl3
+  cmake --build build -j$(nproc)
+  cmake --install build
+  ```
+
+## Build
+
+```sh
+cmake -S . -B build-linux -DCMAKE_BUILD_TYPE=Release -DSDL3_ROOT=/path/to/sdl3
+cmake --build build-linux -j$(nproc)
+```
+
+Outputs (matching the MSVC layout):
+
+- `build/` — `Heretic2R` (executable), `quake2.so`, `H2Common.so`, `ref_gl1.so`, `snd_sdl3.so`
+- `build/base/` — `gamex86.so`, `Player.so`, `Client Effects.so`
+
+`SDL3_ROOT` defaults to `/tmp/sdl3-install`; pass `-DSDL3_ROOT=` to point at your SDL3 prefix.
+
+## How the port works
+
+All Linux-specific code lives under `src/linux/`:
+
+- **`linux_compat.h`** — force-included (via `-include`) before every translation unit.
+  Provides the MSVC "secure CRT" functions (`strcpy_s`, `sprintf_s`, `fopen_s`,
+  `memcpy_s`, …), `min`/`max`, the Win32 types/APIs the engine references outside its
+  platform layer (`HINSTANCE`, `DWORD`, `LoadLibrary`→`dlopen`, `MessageBox`→stderr, …),
+  and maps MSVC keywords (`__declspec`, `__forceinline`, `_stricmp`, …).
+- **`compat/windows.h`, `compat/direct.h`, `compat/io.h`** — stub headers (first on the
+  include path) so the handful of cross-platform files that `#include <windows.h>` compile
+  unchanged.
+- **`sys_unix.c`** — system layer + main loop + `dlopen`-based DLL loading (replaces
+  `win32/sys_win.c`).
+- **`q_shunix.c`** — filesystem/time helpers via POSIX + `glob()` (replaces `win32/q_shwin.c`).
+- **`net_udp.c`** — BSD-sockets UDP networking (replaces `win32/net_wins.c`); IPX is dropped.
+- **`launcher_main.c`** — `main()` entry replacing the Win32 `WinMain`.
+
+`win32/sys_win.c`, `win32/q_shwin.c`, and `win32/net_wins.c` are excluded from the Linux
+build; `win32/vid_Screenshot.c` and `win32/dll_io/*.c` are portable and kept.
+
+### Source changes for GCC
+
+The original code is clean under MSVC but trips several GCC/Linux differences (all small,
+behaviour-preserving, and guarded for Windows where applicable):
+
+- **Case-sensitive includes** — Linux is case-sensitive; Windows is not. A number of
+  `#include`s spell header names with different casing than the file on disk
+  (e.g. `q_shared.h` → `q_Shared.h`, `Monsters/PlaguesSithra` → `PlagueSsithra`).
+  Case-correct symlinks beside the real headers fix this. They are not committed
+  (git symlinks misbehave on Windows), so after a fresh clone run once:
+  `python3 src/linux/gen-case-symlinks.py`
+- `Hunk.c` — `VirtualAlloc`/`VirtualFree` → `mmap`/`munmap` (`#ifdef _WIN32`).
+- `DllMain.c` — Windows `DllMain` → ELF `__attribute__((constructor/destructor))`.
+- `g_ClassStatics.h` — `enum ClassID_e` defined before its includes (GCC rejects an
+  incomplete enum as a struct field; the include cycle made it incomplete).
+- `g_Obj.h`, `ce_*.h`, `gl1_*.h` — file-scope forward declarations so prototype parameters
+  refer to the real struct tags (C tag-scoping rules; MSVC is lax).
+- `q_Shared.c` — `BoxOnPlaneSide` and friends are compiled into several modules, mirroring
+  the MSVC solution.
+- `qcommon.h` — `BUILDSTRING`/`CPUSTRING` defined for non-Windows.
+- `SurfaceProps.c` — definition matched to its `const void*` prototype.
+- `gl1_FlexModel.c` — a stray Latin-1 (`0xF1`) identifier byte replaced with ASCII.
+- `p_items.c` — cosmetic `#pragma region` markers (illegal mid-initializer in GCC) removed.
+
+### Compiler flags of note
+
+`-fcommon` (legacy tentative globals), `-fms-extensions` (forward-declared enums, lax tag
+scoping), and `-Wno-error=` for the constructs GCC 14 promotes to hard errors
+(`incompatible-pointer-types`, `implicit-function-declaration`, `int-conversion`).
+
+## Known limitations / next steps
+
+- 64-bit build (the original is 32-bit x86). Struct layouts are consistent across all
+  modules, but pointer-size assumptions in save/network code are unverified at runtime.
+- IPX networking removed (dead protocol).
+- Runtime not yet validated: needs Heretic II v1.06 game data and an X11/Wayland display.
+- The launcher's RPATH currently points at the build/SDL prefixes; an installed layout
+  would want `$ORIGIN`-relative RPATHs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Heretic2R is a reverse-engineered source port of **Heretic II** (1998, Raven Software), which itself
+is built on the **Quake II engine**. The codebase is C (compiled as C++ in places via MSVC), Win32-only,
+and built for **x86 / Win32** (not x64).
+
+The game needs Heretic II v1.06 game data to run (see README.md). It is not asset- or save-compatible
+with the original Heretic II, and its renderer/sound/game DLLs use changed APIs incompatible with H2's.
+
+## Building
+
+There is no CMake/Makefile — this is a **Visual Studio solution**. Open `src/Heretic2R.sln` in Visual
+Studio and build. Configurations are `Debug|x86` and `Release|x86` only.
+
+Build outputs land in:
+- `build/` — `Heretic2R.exe`, `quake2.dll`, `H2Common.dll`, `ref_gl1.dll`, `snd_sdl3.dll`
+- `build/base/` — `gamex86.dll`, `Player.dll`, `Client Effects.dll` (the moddable game-side DLLs)
+
+`pack_release.bat` zips a release into `release/`, deriving the revision from `VERSION_REVISION` in
+`src/qcommon/Version.h`. Bump `VERSION_REVISION` there when cutting a release.
+
+There are no tests and no lint configuration in this repo.
+
+## Module / DLL architecture
+
+The engine is split into separate DLLs that talk to each other through **import/export struct tables**
+(`*_import_t` provided by the host, `*_export_t` returned by the loaded DLL). DLLs are loaded at runtime
+via `Sys_LoadGameDll` + `GetProcAddress` on a well-known entry point, so they are hot-swappable. The
+project (`src/<name>/`) → output mapping:
+
+| Project (`src/…`)        | Output                | Role |
+|--------------------------|-----------------------|------|
+| `launcher/` (Heretic2R)  | `Heretic2R.exe`       | Thin `WinMain` wrapper; statically links `quake2.lib` and calls `Quake2Main`. |
+| `quake2/`                | `quake2.dll`          | The engine: client, server, Win32 platform layer, and shared engine code (`cs_shared/`). |
+| `H2Common/`              | `H2Common.dll`        | Shared low-level utilities (math, matrices, `ResourceManager`, linked lists, byte order, physics, surface props). Linked by **every** other module. |
+| `game/` (gamex86)        | `base/gamex86.dll`    | Server-side game logic (entities, monsters, spells, physics, scripting, saving). Entry point `GetGameAPI`. |
+| `Player/`                | `base/Player.dll`     | Player animation/action/state machine. Loaded by `gamex86.dll`, not the engine. Interface in `qcommon/p_dll.*`. |
+| `client effects/`        | `base/Client Effects.dll` | Client-side particle/special-effects system. Loaded by the engine (`win32/dll_io/clfx_dll.*`). |
+| `ref_gl1/`               | `ref_gl1.dll`         | OpenGL 1.3 renderer (glad). Loaded via `win32/dll_io/vid_dll.*`. |
+| `snd_sdl3/`              | `snd_sdl3.dll`        | SDL3 sound backend (OGG/WAV, lowpass filter). Loaded via `win32/dll_io/snd_dll.*`. Selected by `snd_dll` cvar. |
+
+Loading order at a glance: `Heretic2R.exe` → `quake2.dll` (engine), which loads the renderer, sound, and
+client-effects DLLs; the engine's server loads `gamex86.dll`, which in turn loads `Player.dll`.
+
+### Shared headers — `src/qcommon/`
+
+`src/qcommon/` is the cross-module header hub (the Quake `q_shared` equivalent): vector/matrix/angle math,
+effect/particle flags, message (netmsg) serialization, skeletons, references, the Player and Physics
+interfaces, and `Version.h`. It is on the include path of essentially every project. When changing a
+struct or constant used across the DLL boundary, both sides must be rebuilt or the API checksum/layout
+will mismatch.
+
+`src/quake2/src/cs_shared/` holds engine code shared between client and server (cmd, cvar, cmodel,
+`pmove`, files, netchan). Third-party libraries live in top-level `include/` (glad GL1.3, libsmacker for
+Smacker cinematics, SDL3, stb) with SDL3 import libs in `lib/SDL3/`.
+
+## Conventions
+
+- **`//mxd` markers**: the maintainer tags modern changes, fixes, and additions to the original Raven
+  code with a `//mxd` comment (thousands of occurrences across the tree). Untagged code is generally the
+  original reverse-engineered 1998 logic. When editing, follow this convention — annotate behavioral
+  changes/additions with `//mxd` (and a short rationale where the original behavior differed, as the
+  existing comments do). Comments often note "original logic did X" to document intentional deviations.
+- Code is organized by subsystem folders within each project (e.g. `game/src/Monsters`, `SpellsOffensive`,
+  `Scripting`, `Saving`, `NavSys`, `Physics`, `GameObjects`).
+- Player/config/save data is stored at runtime under `%USERPROFILE%\Saved Games\Heretic2R`, not the game
+  folder.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ add_compile_options(
     # demotes the C++ narrowing error to a (silenced) warning.
     $<$<COMPILE_LANGUAGE:CXX>:-fpermissive>
 )
-add_compile_definitions(NDEBUG)
+add_compile_definitions(NDEBUG _GNU_SOURCE)  # _GNU_SOURCE: FNM_CASEFOLD, etc.
 
 include_directories(BEFORE
     ${LINUXDIR}/compat   # stub windows.h / direct.h / io.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,187 @@
+#
+# CMakeLists.txt -- Linux build for Heretic2R.
+#
+# Produces the same module layout as the original MSVC solution, as Linux shared
+# objects loaded at runtime via dlopen():
+#   build/      Heretic2R (exe), quake2.so, H2Common.so, ref_gl1.so, snd_sdl3.so
+#   build/base/ gamex86.so, Player.so, "Client Effects.so"
+#
+
+cmake_minimum_required(VERSION 3.16)
+project(Heretic2R C CXX)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED OFF)
+set(CMAKE_CXX_STANDARD 17)            # game scripting subsystem (uses <unordered_map>, etc.)
+set(CMAKE_CXX_STANDARD_REQUIRED OFF)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(SRC      ${CMAKE_SOURCE_DIR}/src)
+set(INCLUDE  ${CMAKE_SOURCE_DIR}/include)
+set(LINUXDIR ${SRC}/linux)
+
+# --- SDL3 (built separately; see notes in CLAUDE.md / build instructions) ------
+set(SDL3_ROOT "/tmp/sdl3-install" CACHE PATH "Prefix containing libSDL3.so")
+find_library(SDL3_LIB NAMES SDL3 PATHS ${SDL3_ROOT}/lib ${SDL3_ROOT}/lib64 NO_DEFAULT_PATH)
+if(NOT SDL3_LIB)
+    find_library(SDL3_LIB NAMES SDL3)
+endif()
+if(NOT SDL3_LIB)
+    message(FATAL_ERROR "libSDL3 not found. Build SDL 3.4.2 and set -DSDL3_ROOT=<prefix>.")
+endif()
+message(STATUS "Using SDL3: ${SDL3_LIB}")
+
+find_package(OpenGL REQUIRED)
+
+# --- Output layout -------------------------------------------------------------
+set(BUILD_DIR  ${CMAKE_SOURCE_DIR}/build)
+set(BASE_DIR   ${BUILD_DIR}/base)
+
+# --- Common compile settings, applied to every target -------------------------
+# Force-include the Win32/MSVC compatibility shim before every TU, and put the
+# stub <windows.h> et al. first on the include path so the ~6 cross-platform
+# files that include <windows.h> resolve to the shim.
+add_compile_options(
+    -include ${LINUXDIR}/linux_compat.h
+    -fcommon            # old-style tentative globals shared across TUs
+    -fms-extensions     # forward-declared enums; lax prototype tag scoping
+    -fno-strict-aliasing
+    -w                  # silence the (very large) legacy warning set
+)
+# GCC 14+ promotes these legacy-C constructs to hard errors; the code is
+# clean under MSVC, so demote them back to (silenced) warnings. C-only.
+add_compile_options(
+    $<$<COMPILE_LANGUAGE:C>:-Wno-error=incompatible-pointer-types>
+    $<$<COMPILE_LANGUAGE:C>:-Wno-error=int-conversion>
+    $<$<COMPILE_LANGUAGE:C>:-Wno-error=implicit-function-declaration>
+    $<$<COMPILE_LANGUAGE:C>:-Wno-error=implicit-int>
+    # C++ analog: the field-offset macros (FOFS/STOFS/...) cast null-based member
+    # pointers to int. The offsets fit in int (32-bit-origin structs); -fpermissive
+    # demotes the C++ narrowing error to a (silenced) warning.
+    $<$<COMPILE_LANGUAGE:CXX>:-fpermissive>
+)
+add_compile_definitions(NDEBUG)
+
+include_directories(BEFORE
+    ${LINUXDIR}/compat   # stub windows.h / direct.h / io.h
+    ${LINUXDIR}
+)
+include_directories(
+    ${INCLUDE}
+    ${INCLUDE}/glad-GL1.3
+    ${SRC}/qcommon
+    ${SRC}/game/src
+    ${SRC}/Player/src
+)
+
+# Helper: strip the "lib" prefix so module names match the originals.
+function(h2_module target outdir)
+    set_target_properties(${target} PROPERTIES
+        PREFIX ""
+        LIBRARY_OUTPUT_DIRECTORY ${outdir}
+        C_VISIBILITY_PRESET default)
+endfunction()
+
+# ============================== H2Common.so ===================================
+file(GLOB H2COMMON_SRC ${SRC}/H2Common/src/*.c)
+# q_Shared.c (BoxOnPlaneSide and other shared helpers) is compiled into several
+# modules by the original MSVC solution; mirror that here.
+list(APPEND H2COMMON_SRC ${SRC}/game/src/q_Shared.c)
+add_library(H2Common SHARED ${H2COMMON_SRC})
+target_include_directories(H2Common PRIVATE ${SRC}/H2Common/src)
+h2_module(H2Common ${BUILD_DIR})
+target_link_libraries(H2Common PRIVATE m)
+
+# ============================== quake2.so (engine) ============================
+file(GLOB_RECURSE QUAKE2_SRC ${SRC}/quake2/src/*.c)
+# Drop the Windows-only platform files (replaced by src/linux equivalents).
+list(FILTER QUAKE2_SRC EXCLUDE REGEX "/win32/(net_wins|q_shwin|sys_win)\\.c$")
+list(APPEND QUAKE2_SRC
+    ${LINUXDIR}/sys_unix.c
+    ${LINUXDIR}/q_shunix.c
+    ${LINUXDIR}/net_udp.c
+    ${SRC}/qcommon/anorms.c
+    ${SRC}/qcommon/netmsg_read.c
+    ${SRC}/qcommon/netmsg_write.c
+    ${SRC}/qcommon/p_dll.c
+    ${SRC}/qcommon/Reference.c
+    ${SRC}/qcommon/Skeletons.c
+    ${SRC}/qcommon/turbsin.c
+    ${SRC}/game/src/q_Shared.c
+    ${INCLUDE}/libsmacker/smacker.c
+)
+add_library(quake2 SHARED ${QUAKE2_SRC})
+target_compile_definitions(quake2 PRIVATE QUAKE2_DLL)
+target_include_directories(quake2 PRIVATE
+    ${SRC}/quake2/src
+    ${SRC}/quake2/src/client
+    ${SRC}/quake2/src/server)
+h2_module(quake2 ${BUILD_DIR})
+target_link_libraries(quake2 PRIVATE H2Common ${SDL3_LIB} ${CMAKE_DL_LIBS} m pthread)
+
+# ============================== ref_gl1.so (renderer) =========================
+file(GLOB_RECURSE REFGL1_SRC ${SRC}/ref_gl1/src/*.c)
+list(APPEND REFGL1_SRC
+    ${INCLUDE}/glad-GL1.3/glad.c
+    ${SRC}/qcommon/anorms.c
+    ${SRC}/qcommon/Reference.c
+    ${SRC}/qcommon/Skeletons.c
+    ${SRC}/qcommon/turbsin.c
+    ${SRC}/game/src/q_Shared.c)
+add_library(ref_gl1 SHARED ${REFGL1_SRC})
+target_include_directories(ref_gl1 PRIVATE ${SRC}/ref_gl1/src ${SRC}/quake2/src)
+h2_module(ref_gl1 ${BUILD_DIR})
+target_link_libraries(ref_gl1 PRIVATE H2Common ${SDL3_LIB} OpenGL::GL ${CMAKE_DL_LIBS} m)
+
+# ============================== snd_sdl3.so (sound) ===========================
+file(GLOB_RECURSE SND_SRC ${SRC}/snd_sdl3/src/*.c)
+add_library(snd_sdl3 SHARED ${SND_SRC})
+target_include_directories(snd_sdl3 PRIVATE ${SRC}/snd_sdl3/src ${SRC}/quake2/src/client)
+h2_module(snd_sdl3 ${BUILD_DIR})
+target_link_libraries(snd_sdl3 PRIVATE H2Common ${SDL3_LIB} m)
+
+# ============================== gamex86.so ====================================
+file(GLOB_RECURSE GAME_SRC ${SRC}/game/src/*.c)
+# The scripting subsystem (game/src/Scripting/**) is C++.
+file(GLOB_RECURSE GAME_CXX_SRC ${SRC}/game/src/*.cpp)
+list(APPEND GAME_SRC ${GAME_CXX_SRC}
+    ${SRC}/qcommon/Message.c
+    ${SRC}/qcommon/p_dll.c
+    ${SRC}/qcommon/Skeletons.c)
+add_library(gamex86 SHARED ${GAME_SRC})
+target_compile_definitions(gamex86 PRIVATE GAME_DLL)
+target_include_directories(gamex86 PRIVATE ${SRC}/game/src)
+h2_module(gamex86 ${BASE_DIR})
+target_link_libraries(gamex86 PRIVATE H2Common quake2 m)
+
+# ============================== Player.so =====================================
+file(GLOB_RECURSE PLAYER_SRC ${SRC}/Player/src/*.c)
+list(APPEND PLAYER_SRC ${SRC}/game/src/q_Shared.c)
+add_library(Player SHARED ${PLAYER_SRC})
+target_compile_definitions(Player PRIVATE PLAYER_DLL)
+target_include_directories(Player PRIVATE ${SRC}/Player/src)
+h2_module(Player ${BASE_DIR})
+target_link_libraries(Player PRIVATE H2Common quake2 m)
+
+# ============================== Client Effects.so =============================
+file(GLOB_RECURSE CLFX_SRC "${SRC}/client effects/src/*.c")
+list(APPEND CLFX_SRC
+    ${SRC}/qcommon/anorms.c
+    ${SRC}/qcommon/Message.c
+    ${SRC}/qcommon/netmsg_read.c
+    ${SRC}/qcommon/turbsin.c)
+add_library(ClientEffects SHARED ${CLFX_SRC})
+target_include_directories(ClientEffects PRIVATE "${SRC}/client effects/src" ${SRC}/quake2/src)
+set_target_properties(ClientEffects PROPERTIES
+    PREFIX "" OUTPUT_NAME "Client Effects"
+    LIBRARY_OUTPUT_DIRECTORY ${BASE_DIR})
+target_link_libraries(ClientEffects PRIVATE H2Common quake2 m)
+
+# ============================== Heretic2R (launcher exe) ======================
+add_executable(Heretic2R ${LINUXDIR}/launcher_main.c)
+target_include_directories(Heretic2R PRIVATE ${SRC}/quake2/src)
+set_target_properties(Heretic2R PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${BUILD_DIR})
+target_link_libraries(Heretic2R PRIVATE quake2 ${CMAKE_DL_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,5 @@
 #
-# CMakeLists.txt -- Linux build for Heretic2R.
-#
-# Produces the same module layout as the original MSVC solution, as Linux shared
-# objects loaded at runtime via dlopen():
-#   build/      Heretic2R (exe), quake2.so, H2Common.so, ref_gl1.so, snd_sdl3.so
-#   build/base/ gamex86.so, Player.so, "Client Effects.so"
+# CMakeLists.txt -- Heretic2R build (Linux & Windows/MinGW).
 #
 
 cmake_minimum_required(VERSION 3.16)
@@ -12,7 +7,7 @@ project(Heretic2R C CXX)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED OFF)
-set(CMAKE_CXX_STANDARD 17)            # game scripting subsystem (uses <unordered_map>, etc.)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED OFF)
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -23,86 +18,109 @@ set(SRC      ${CMAKE_SOURCE_DIR}/src)
 set(INCLUDE  ${CMAKE_SOURCE_DIR}/include)
 set(LINUXDIR ${SRC}/linux)
 
-# --- SDL3 (built separately; see notes in CLAUDE.md / build instructions) ------
-set(SDL3_ROOT "/tmp/sdl3-install" CACHE PATH "Prefix containing libSDL3.so")
-find_library(SDL3_LIB NAMES SDL3 PATHS ${SDL3_ROOT}/lib ${SDL3_ROOT}/lib64 NO_DEFAULT_PATH)
+# --- SDL3 ----------------------------------------------------------------------
+if(WIN32)
+    set(SDL3_ROOT "/root/win32-install" CACHE PATH "Prefix containing SDL3.dll")
+else()
+    set(SDL3_ROOT "/tmp/sdl3-install" CACHE PATH "Prefix containing libSDL3.so")
+endif()
+
+find_library(SDL3_LIB NAMES SDL3 PATHS ${SDL3_ROOT}/lib ${SDL3_ROOT}/bin NO_DEFAULT_PATH)
 if(NOT SDL3_LIB)
     find_library(SDL3_LIB NAMES SDL3)
 endif()
 if(NOT SDL3_LIB)
-    message(FATAL_ERROR "libSDL3 not found. Build SDL 3.4.2 and set -DSDL3_ROOT=<prefix>.")
+    message(FATAL_ERROR "libSDL3 not found.")
 endif()
 message(STATUS "Using SDL3: ${SDL3_LIB}")
 
-find_package(OpenGL REQUIRED)
+if(NOT WIN32)
+    find_package(OpenGL REQUIRED)
+endif()
 
 # --- Output layout -------------------------------------------------------------
-set(BUILD_DIR  ${CMAKE_SOURCE_DIR}/build)
+if(WIN32)
+    set(BUILD_DIR  ${CMAKE_SOURCE_DIR}/build-win32)
+else()
+    set(BUILD_DIR  ${CMAKE_SOURCE_DIR}/build)
+endif()
 set(BASE_DIR   ${BUILD_DIR}/base)
 
-# --- Common compile settings, applied to every target -------------------------
-# Force-include the Win32/MSVC compatibility shim before every TU, and put the
-# stub <windows.h> et al. first on the include path so the ~6 cross-platform
-# files that include <windows.h> resolve to the shim.
+# --- Common compile settings --------------------------------------------------
+if(WIN32)
+    add_compile_options(-include ${SRC}/win32_cross_compat.h)
+else()
+    add_compile_options(-include ${LINUXDIR}/linux_compat.h)
+endif()
+
 add_compile_options(
-    -include ${LINUXDIR}/linux_compat.h
-    -fcommon            # old-style tentative globals shared across TUs
-    -fms-extensions     # forward-declared enums; lax prototype tag scoping
+    -fcommon
+    -fms-extensions
     -fno-strict-aliasing
-    -w                  # silence the (very large) legacy warning set
+    -w
 )
-# GCC 14+ promotes these legacy-C constructs to hard errors; the code is
-# clean under MSVC, so demote them back to (silenced) warnings. C-only.
+
 add_compile_options(
     $<$<COMPILE_LANGUAGE:C>:-Wno-error=incompatible-pointer-types>
     $<$<COMPILE_LANGUAGE:C>:-Wno-error=int-conversion>
     $<$<COMPILE_LANGUAGE:C>:-Wno-error=implicit-function-declaration>
     $<$<COMPILE_LANGUAGE:C>:-Wno-error=implicit-int>
-    # C++ analog: the field-offset macros (FOFS/STOFS/...) cast null-based member
-    # pointers to int. The offsets fit in int (32-bit-origin structs); -fpermissive
-    # demotes the C++ narrowing error to a (silenced) warning.
     $<$<COMPILE_LANGUAGE:CXX>:-fpermissive>
 )
-add_compile_definitions(NDEBUG _GNU_SOURCE)  # _GNU_SOURCE: FNM_CASEFOLD, etc.
+add_compile_definitions(NDEBUG)
+if(NOT WIN32)
+    add_compile_definitions(_GNU_SOURCE)
+endif()
 
-include_directories(BEFORE
-    ${LINUXDIR}/compat   # stub windows.h / direct.h / io.h
-    ${LINUXDIR}
-)
+if(NOT WIN32)
+    include_directories(BEFORE
+        ${LINUXDIR}/compat
+        ${LINUXDIR}
+    )
+endif()
+
 include_directories(
     ${INCLUDE}
     ${INCLUDE}/glad-GL1.3
     ${SRC}/qcommon
     ${SRC}/game/src
     ${SRC}/Player/src
+    ${CMAKE_SOURCE_DIR}/include/cross_compat
 )
 
-# Helper: strip the "lib" prefix so module names match the originals.
 function(h2_module target outdir)
     set_target_properties(${target} PROPERTIES
         PREFIX ""
         LIBRARY_OUTPUT_DIRECTORY ${outdir}
+        RUNTIME_OUTPUT_DIRECTORY ${outdir}
         C_VISIBILITY_PRESET default)
 endfunction()
 
-# ============================== H2Common.so ===================================
+# ============================== H2Common ======================================
 file(GLOB H2COMMON_SRC ${SRC}/H2Common/src/*.c)
-# q_Shared.c (BoxOnPlaneSide and other shared helpers) is compiled into several
-# modules by the original MSVC solution; mirror that here.
 list(APPEND H2COMMON_SRC ${SRC}/game/src/q_Shared.c)
 add_library(H2Common SHARED ${H2COMMON_SRC})
+target_compile_definitions(H2Common PRIVATE H2COMMON)
 target_include_directories(H2Common PRIVATE ${SRC}/H2Common/src)
 h2_module(H2Common ${BUILD_DIR})
-target_link_libraries(H2Common PRIVATE m)
+if(NOT WIN32)
+    target_link_libraries(H2Common PRIVATE m)
+endif()
 
-# ============================== quake2.so (engine) ============================
+# ============================== quake2 (engine) ===============================
 file(GLOB_RECURSE QUAKE2_SRC ${SRC}/quake2/src/*.c)
-# Drop the Windows-only platform files (replaced by src/linux equivalents).
-list(FILTER QUAKE2_SRC EXCLUDE REGEX "/win32/(net_wins|q_shwin|sys_win)\\.c$")
+if(WIN32)
+    list(FILTER QUAKE2_SRC EXCLUDE REGEX "/linux/.*")
+else()
+    list(FILTER QUAKE2_SRC EXCLUDE REGEX "/win32/(net_wins|q_shwin|sys_win)\\.c$")
+    list(APPEND QUAKE2_SRC
+        ${LINUXDIR}/sys_unix.c
+        ${LINUXDIR}/q_shunix.c
+        ${LINUXDIR}/net_udp.c
+    )
+endif()
+
 list(APPEND QUAKE2_SRC
-    ${LINUXDIR}/sys_unix.c
-    ${LINUXDIR}/q_shunix.c
-    ${LINUXDIR}/net_udp.c
     ${SRC}/qcommon/anorms.c
     ${SRC}/qcommon/netmsg_read.c
     ${SRC}/qcommon/netmsg_write.c
@@ -120,9 +138,13 @@ target_include_directories(quake2 PRIVATE
     ${SRC}/quake2/src/client
     ${SRC}/quake2/src/server)
 h2_module(quake2 ${BUILD_DIR})
-target_link_libraries(quake2 PRIVATE H2Common ${SDL3_LIB} ${CMAKE_DL_LIBS} m pthread)
+if(WIN32)
+    target_link_libraries(quake2 PRIVATE H2Common ${SDL3_LIB} ws2_32 winmm)
+else()
+    target_link_libraries(quake2 PRIVATE H2Common ${SDL3_LIB} ${CMAKE_DL_LIBS} m pthread)
+endif()
 
-# ============================== ref_gl1.so (renderer) =========================
+# ============================== ref_gl1 (renderer) ============================
 file(GLOB_RECURSE REFGL1_SRC ${SRC}/ref_gl1/src/*.c)
 list(APPEND REFGL1_SRC
     ${INCLUDE}/glad-GL1.3/glad.c
@@ -134,18 +156,24 @@ list(APPEND REFGL1_SRC
 add_library(ref_gl1 SHARED ${REFGL1_SRC})
 target_include_directories(ref_gl1 PRIVATE ${SRC}/ref_gl1/src ${SRC}/quake2/src)
 h2_module(ref_gl1 ${BUILD_DIR})
-target_link_libraries(ref_gl1 PRIVATE H2Common ${SDL3_LIB} OpenGL::GL ${CMAKE_DL_LIBS} m)
+if(WIN32)
+    target_link_libraries(ref_gl1 PRIVATE H2Common ${SDL3_LIB} opengl32)
+else()
+    target_link_libraries(ref_gl1 PRIVATE H2Common ${SDL3_LIB} OpenGL::GL ${CMAKE_DL_LIBS} m)
+endif()
 
-# ============================== snd_sdl3.so (sound) ===========================
+# ============================== snd_sdl3 (sound) ==============================
 file(GLOB_RECURSE SND_SRC ${SRC}/snd_sdl3/src/*.c)
 add_library(snd_sdl3 SHARED ${SND_SRC})
 target_include_directories(snd_sdl3 PRIVATE ${SRC}/snd_sdl3/src ${SRC}/quake2/src/client)
 h2_module(snd_sdl3 ${BUILD_DIR})
-target_link_libraries(snd_sdl3 PRIVATE H2Common ${SDL3_LIB} m)
+target_link_libraries(snd_sdl3 PRIVATE H2Common ${SDL3_LIB})
+if(NOT WIN32)
+    target_link_libraries(snd_sdl3 PRIVATE m)
+endif()
 
-# ============================== gamex86.so ====================================
+# ============================== gamex86 =======================================
 file(GLOB_RECURSE GAME_SRC ${SRC}/game/src/*.c)
-# The scripting subsystem (game/src/Scripting/**) is C++.
 file(GLOB_RECURSE GAME_CXX_SRC ${SRC}/game/src/*.cpp)
 list(APPEND GAME_SRC ${GAME_CXX_SRC}
     ${SRC}/qcommon/Message.c
@@ -155,18 +183,24 @@ add_library(gamex86 SHARED ${GAME_SRC})
 target_compile_definitions(gamex86 PRIVATE GAME_DLL)
 target_include_directories(gamex86 PRIVATE ${SRC}/game/src)
 h2_module(gamex86 ${BASE_DIR})
-target_link_libraries(gamex86 PRIVATE H2Common quake2 m)
+target_link_libraries(gamex86 PRIVATE H2Common quake2)
+if(NOT WIN32)
+    target_link_libraries(gamex86 PRIVATE m)
+endif()
 
-# ============================== Player.so =====================================
+# ============================== Player ========================================
 file(GLOB_RECURSE PLAYER_SRC ${SRC}/Player/src/*.c)
 list(APPEND PLAYER_SRC ${SRC}/game/src/q_Shared.c)
 add_library(Player SHARED ${PLAYER_SRC})
 target_compile_definitions(Player PRIVATE PLAYER_DLL)
 target_include_directories(Player PRIVATE ${SRC}/Player/src)
 h2_module(Player ${BASE_DIR})
-target_link_libraries(Player PRIVATE H2Common quake2 m)
+target_link_libraries(Player PRIVATE H2Common quake2)
+if(NOT WIN32)
+    target_link_libraries(Player PRIVATE m)
+endif()
 
-# ============================== Client Effects.so =============================
+# ============================== Client Effects ================================
 file(GLOB_RECURSE CLFX_SRC "${SRC}/client effects/src/*.c")
 list(APPEND CLFX_SRC
     ${SRC}/qcommon/anorms.c
@@ -177,11 +211,24 @@ add_library(ClientEffects SHARED ${CLFX_SRC})
 target_include_directories(ClientEffects PRIVATE "${SRC}/client effects/src" ${SRC}/quake2/src)
 set_target_properties(ClientEffects PROPERTIES
     PREFIX "" OUTPUT_NAME "Client Effects"
-    LIBRARY_OUTPUT_DIRECTORY ${BASE_DIR})
-target_link_libraries(ClientEffects PRIVATE H2Common quake2 m)
+    LIBRARY_OUTPUT_DIRECTORY ${BASE_DIR}
+    RUNTIME_OUTPUT_DIRECTORY ${BASE_DIR}
+    C_VISIBILITY_PRESET default)
+target_link_libraries(ClientEffects PRIVATE H2Common quake2)
+if(NOT WIN32)
+    target_link_libraries(ClientEffects PRIVATE m)
+endif()
 
-# ============================== Heretic2R (launcher exe) ======================
-add_executable(Heretic2R ${LINUXDIR}/launcher_main.c)
+# ============================== Launcher ======================================
+if(WIN32)
+    set(LAUNCHER_SRC ${SRC}/launcher/src/main.c)
+else()
+    set(LAUNCHER_SRC ${LINUXDIR}/launcher_main.c)
+endif()
+add_executable(Heretic2R ${LAUNCHER_SRC})
 target_include_directories(Heretic2R PRIVATE ${SRC}/quake2/src)
-set_target_properties(Heretic2R PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${BUILD_DIR})
-target_link_libraries(Heretic2R PRIVATE quake2 ${CMAKE_DL_LIBS})
+h2_module(Heretic2R ${BUILD_DIR})
+target_link_libraries(Heretic2R PRIVATE quake2)
+if(WIN32)
+    set_target_properties(Heretic2R PROPERTIES WIN32_EXECUTABLE TRUE)
+endif()

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# run.sh — launch Heretic2R on Linux.
+#
+# Wires up the runtime environment the CMake build expects (see BUILDING-linux.md):
+#   - cd into the build dir so the engine finds ./base and dlopen()s the engine
+#     modules (quake2.so, ref_gl1.so, snd_sdl3.so) via the executable's RUNPATH.
+#   - make libSDL3.so locatable (it is built separately, not installed system-wide).
+#
+# Usage:
+#   ./run.sh [game args...]            # e.g. ./run.sh +set vid_fullscreen 0
+#
+# Environment overrides:
+#   BUILD=build-dbg ./run.sh          # pick a different build tree (default: build)
+#   SDL3_ROOT=/path/to/sdl3 ./run.sh  # SDL3 install prefix (overrides auto-detection)
+#
+set -euo pipefail
+
+REPO="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+BUILD="${BUILD:-build}"
+BUILD_DIR="$REPO/$BUILD"
+EXE="$BUILD_DIR/Heretic2R"
+
+# SDL3 is built separately (see BUILDING-linux.md). Honour SDL3_ROOT if set,
+# otherwise probe the usual prefixes.
+SDL3_CANDIDATES=("${SDL3_ROOT:-}" "$HOME/sdl3-install" /tmp/sdl3-install /usr/local)
+
+die() { echo "run.sh: $*" >&2; exit 1; }
+
+[ -x "$EXE" ] || die "no executable at $EXE
+  Build first:  cmake --build $BUILD -j\$(nproc)   (see BUILDING-linux.md)"
+
+[ -d "$BUILD_DIR/base" ] || die "missing game data at $BUILD_DIR/base
+  Copy a Heretic II v1.06 'base' folder there (see README.md)."
+
+# Locate libSDL3.so.* — built separately, so it is usually not on the default
+# loader path. Search the candidate prefixes, then let the loader's config decide.
+sdl_libdir=""
+for root in "${SDL3_CANDIDATES[@]}"; do
+    [ -n "$root" ] || continue
+    for d in "$root/lib" "$root/lib64"; do
+        if compgen -G "$d/libSDL3.so*" > /dev/null 2>&1; then
+            sdl_libdir="$d"
+            break 2
+        fi
+    done
+done
+
+if [ -n "$sdl_libdir" ]; then
+    export LD_LIBRARY_PATH="$sdl_libdir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+elif ! ldconfig -p 2>/dev/null | grep -q 'libSDL3\.so'; then
+    die "libSDL3.so not found under ${SDL3_CANDIDATES[*]} or on the system loader path.
+  Build SDL 3.4.2 and point SDL3_ROOT at its install prefix (see BUILDING-linux.md),
+  e.g.  SDL3_ROOT=/path/to/sdl3 ./run.sh"
+fi
+
+cd "$BUILD_DIR"
+exec ./Heretic2R "$@"

--- a/run_win32.sh
+++ b/run_win32.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# run_win32.sh — launch Heretic2R Windows build via Wine.
+#
+
+REPO="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="$REPO/build-win32"
+EXE="$BUILD_DIR/Heretic2R.exe"
+
+if [ ! -f "$EXE" ]; then
+    echo "Executable not found at $EXE"
+    exit 1
+fi
+
+if [ ! -d "$BUILD_DIR/base" ]; then
+    echo "Warning: missing game data at $BUILD_DIR/base"
+    echo "Copy a Heretic II v1.06 'base' folder there (see README.md)."
+fi
+
+cd "$BUILD_DIR"
+wine ./Heretic2R.exe "$@"

--- a/src/H2Common/src/DllMain.c
+++ b/src/H2Common/src/DllMain.c
@@ -4,11 +4,14 @@
 // Copyright 1998 Raven Software
 //
 
-#include <windows.h>
 #include "ResourceManager.h"
 #include "SinglyLinkedList.h"
 
 extern ResourceManager_t sllist_nodes_mgr;
+
+#ifdef _WIN32
+
+#include <windows.h>
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
@@ -28,3 +31,18 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 
 	return TRUE;
 }
+
+#else
+
+// On Linux the .so is initialized/finalized via ELF constructor/destructor.
+__attribute__((constructor)) static void H2Common_Attach(void)
+{
+	ResMngr_Con(&sllist_nodes_mgr, SLL_NODE_SIZE, SLL_NODE_BLOCK_SIZE);
+}
+
+__attribute__((destructor)) static void H2Common_Detach(void)
+{
+	ResMngr_Des(&sllist_nodes_mgr);
+}
+
+#endif

--- a/src/H2Common/src/SurfaceProps.c
+++ b/src/H2Common/src/SurfaceProps.c
@@ -8,10 +8,14 @@
 #include "p_types.h"
 
 //TODO: mxd. Seems to be used in Player.dll only. Move there?
-H2COMMON_API char* GetClientGroundSurfaceMaterialName(const playerinfo_t* info)
+// NB: the prototype in SurfaceProps.h declares 'info' as const void* (to avoid
+// dragging playerinfo_t into every includer); MSVC tolerates the mismatched
+// definition, GCC does not, so match the prototype and cast here.
+H2COMMON_API char* GetClientGroundSurfaceMaterialName(const void* info_)
 {
 #define NUM_MATERIALS (sizeof(material_names) / sizeof(material_names[0]))
 	static char* material_names[] = { "gravel", "metal", "stone", "wood" };
+	const playerinfo_t* info = info_;
 
 	if (info->GroundSurface != NULL)
 	{

--- a/src/Player/src/p_items.c
+++ b/src/Player/src/p_items.c
@@ -16,7 +16,6 @@
 PLAYER_API int p_num_items = 0;
 PLAYER_API gitem_t* p_itemlist = NULL;
 
-#pragma region ========================== ITEMS LIST ==========================
 
 //mxd. Originally defined in p_types.h
 #define PICKUP_MIN	{ -10.0f, -10.0f, -10.0f } //mxd. Originally {0, 0, 0}.
@@ -28,7 +27,6 @@ static gitem_t itemlist[] =
 	// Leave index 0 empty.
 	{ 0 },
 
-#pragma region ========================== WEAPONS ==========================
 
 	{ // 1
 		.classname = "Weapon_SwordStaff",				// Spawnname (char *).
@@ -181,9 +179,7 @@ static gitem_t itemlist[] =
 		.icon = "icons/i_mace.m8",						// Icon name (char *).
 	},
 
-#pragma endregion
 
-#pragma region ========================== DEFENSE POWERUPS ==========================
 
 	{ // 10
 		.classname = "item_defense_powerup",			// Spawnname (char *).
@@ -287,9 +283,7 @@ static gitem_t itemlist[] =
 		.icon = "icons/i_meteor.m8",					// Icon name (char *).
 	},
 
-#pragma endregion
 
-#pragma region ========================== AMMO ==========================
 
 	{ // 16
 		.classname = "item_mana_offensive_half",		// Spawnname (char *).
@@ -402,9 +396,7 @@ static gitem_t itemlist[] =
 		.icon = "icons/i_ammo-hellstaff.m8",			// Icon name (char *).
 	},
 
-#pragma endregion
 
-#pragma region ========================== HEALTH ==========================
 
 	{ // 25
 		.classname = "item_health_half",				// Spawnname (char *).
@@ -430,9 +422,7 @@ static gitem_t itemlist[] =
 		.tag = ITEM_HEALTH2,							// Tag. //mxd. MODEL_HEALTH2 in original logic.
 	},
 
-#pragma endregion
 
-#pragma region ========================== PUZZLE PIECES ==========================
 
 	{ // 27
 		.classname = "item_puzzle_townkey",				// Spawnname (char *).
@@ -694,7 +684,6 @@ static gitem_t itemlist[] =
 		.icon = "icons/p_tavernkey.m8",					// Icon name (char *).
 	},
 
-#pragma endregion
 
 	{ // 47 //TODO: move to 'defence powerups' category? Will that break vanilla compatibility?
 		.classname = "item_defense_tornado",			// Spawnname (char *).
@@ -717,7 +706,6 @@ static gitem_t itemlist[] =
 	{ 0 }
 };
 
-#pragma endregion
 
 PLAYER_API void InitItems(void)
 {

--- a/src/client effects/src/ce_DefaultMessageHandler.h
+++ b/src/client effects/src/ce_DefaultMessageHandler.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+struct client_entity_s; // Linux port: file-scope forward decl for GCC tag scoping.
+
 #include "ce_Message.h"
 
 extern void CE_DefaultMsgHandler(struct client_entity_s* self, CE_Message_t* msg);

--- a/src/client effects/src/ce_Main.c
+++ b/src/client effects/src/ce_Main.c
@@ -40,13 +40,22 @@ int numrenderedparticles;
 
 static int num_owned_inview;
 
+// Linux: fxe.Clear can be invoked (via CL_ClearSkeletalEntities on connect) before
+// the client-effects subsystem's Init() has set up its managers. On Windows the
+// startup probe leaves fxe.Clear NULL until then; the dlsym-based guard behaves
+// differently here, so Clear() can fire early. Bail out until Init() has run.
+static qboolean ce_initialized;
+
 static void Clear(void)
 {
+	if (!ce_initialized)
+		return;
+
 	if (clientEnts != NULL)
 		RemoveEffectList(&clientEnts);
 
 	centity_t* owner = fxi.server_entities;
-	for (int i = 0; i < MAX_NETWORKABLE_EDICTS; i++, owner++)
+	for (int i = 0; owner != NULL && i < MAX_NETWORKABLE_EDICTS; i++, owner++)
 	{
 		if (owner->effects != NULL)
 			RemoveOwnedEffectList(owner);
@@ -93,6 +102,7 @@ static void Init(void)
 	cl_lerpdist2 = Cvar_Get("cl_lerpdist2", "10000", 0);
 	vid_ref = Cvar_Get("vid_ref", "soft", CVAR_ARCHIVE);
 
+	ce_initialized = true; // managers are now set up; Clear() is safe.
 	Clear();
 }
 

--- a/src/client effects/src/ce_Message.h
+++ b/src/client effects/src/ce_Message.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+struct client_entity_s; // Linux port: file-scope forward decl for GCC tag scoping.
+
 #include "SinglyLinkedList.h"
 
 typedef enum CE_MsgID_e

--- a/src/client effects/src/ce_Particles.h
+++ b/src/client effects/src/ce_Particles.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+struct client_entity_s; struct client_particle_s; // Linux port: file-scope forward decl for GCC tag scoping.
+
 #include "q_Typedef.h"
 #include "ParticleFlags.h" //mxd
 

--- a/src/game/src/GameObjects/g_Obj.h
+++ b/src/game/src/GameObjects/g_Obj.h
@@ -10,6 +10,11 @@
 #include "q_Typedef.h"
 #include "q_Shared.h"
 
+// Forward-declare at file scope so the 'struct G_Message_s*' parameter below refers
+// to the real (g_Message.h) type rather than a prototype-scoped tag. MSVC is lax
+// about this; GCC enforces C tag scoping rules. -- Linux port.
+struct G_Message_s;
+
 // Spawnflags for object entities.
 #define SF_OBJ_INVULNERABLE		1
 #define SF_OBJ_ANIMATE			2

--- a/src/game/src/Saving/g_Save.c
+++ b/src/game/src/Saving/g_Save.c
@@ -446,7 +446,11 @@ static void ReadField(FILE* f, const field_t* field, byte* base)
 			break;
 
 		case F_CLEAR: //mxd. Some fields should not be restored...
-			*(int*)p = 0;
+			// 64-bit: F_CLEAR fields are pointers (e.g. playerinfo.GroundSurface). The
+			// original "*(int*)p = 0" only zeroed the low 4 bytes of the 8-byte pointer,
+			// leaving the saved pointer's high half -> a garbage pointer that the game
+			// then dereferenced and crashed on. Clear the whole pointer. // Linux port
+			*(void**)p = NULL;
 			break;
 
 		case F_LSTRING:
@@ -467,7 +471,7 @@ static void ReadField(FILE* f, const field_t* field, byte* base)
 		case F_EDICT:
 			index = *(int*)p;
 			if (index == -2) //mxd. Very special "hit world" case (probably used by gclient_t.lastentityhit only)...
-				*(int*)p = -1;
+				*(intptr_t*)p = -1; // 64-bit: write the full pointer-sized -1 marker (not just the low 4 bytes). // Linux port
 			else if (index == -1)
 				*(edict_t**)p = NULL;
 			else

--- a/src/game/src/g_ClassStatics.h
+++ b/src/game/src/g_ClassStatics.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
-#include "g_Message.h"
-#include "g_Local.h"
+// NB (Linux port): enum ClassID_e must be fully defined before the includes below.
+// g_Local.h pulls in g_Edict.h, whose 'edict_s' struct has an 'enum ClassID_e' field;
+// GCC rejects an incomplete enum as a struct field (MSVC silently allows it). Defining
+// the enum first breaks the g_ClassStatics.h -> g_Local.h -> g_Edict.h include cycle.
 
 // If you add or remove classID's here, you MUST adjust the tables in m_stats.c accordingly, as well as the StaticsInit and Precache stuff.
 // Search for "NUM_CLASSIDS" if you're not certain what's effected by this...
@@ -75,6 +77,10 @@ typedef enum ClassID_e
 
 	NUM_CLASSIDS
 } ClassID_t;
+
+// Included here (not at the top) so enum ClassID_e is complete first — see note above.
+#include "g_Message.h"
+#include "g_Local.h"
 
 #define NUM_ATTACK_RANGES	(NUM_CLASSIDS * 4)
 

--- a/src/linux/compat/direct.h
+++ b/src/linux/compat/direct.h
@@ -1,0 +1,3 @@
+// Linux stub for <direct.h> (_mkdir et al.) — redirects to the compatibility shim.
+#pragma once
+#include "../linux_compat.h"

--- a/src/linux/compat/io.h
+++ b/src/linux/compat/io.h
@@ -1,0 +1,3 @@
+// Linux stub for <io.h> — redirects to the compatibility shim.
+#pragma once
+#include "../linux_compat.h"

--- a/src/linux/compat/windows.h
+++ b/src/linux/compat/windows.h
@@ -1,0 +1,3 @@
+// Linux stub for <windows.h> — redirects to the compatibility shim.
+#pragma once
+#include "../linux_compat.h"

--- a/src/linux/gen-case-symlinks.py
+++ b/src/linux/gen-case-symlinks.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+#
+# gen-case-symlinks.py -- recreate case-correct header symlinks for the Linux build.
+#
+# Heretic2R was developed on Windows (case-insensitive paths), so a number of
+# #include directives spell header names with different casing than the file on
+# disk (e.g. #include "q_shared.h" vs the actual q_Shared.h). Linux filesystems
+# are case-sensitive, so those includes fail. Rather than edit hundreds of source
+# files, this script creates a symlink next to each real header for every distinct
+# include spelling that differs only by case. A symlink beside the real file
+# resolves both "Subdir/foo.h" (from a base include dir) and "foo.h" (from a sibling).
+#
+# These symlinks are intentionally NOT committed (git symlinks misbehave on the
+# project's primary Windows checkouts); run this once after a fresh clone:
+#
+#     python3 src/linux/gen-case-symlinks.py
+#
+# Also creates the one misspelled directory symlink (PlaguesSithra -> PlagueSsithra).
+
+import os, re, sys
+
+SRC = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+SRC = os.path.normpath(SRC)
+
+# lowercased basename -> (actual_basename, dir)
+actual = {}
+for dp, _, fs in os.walk(SRC):
+    if os.sep + ".git" in dp:
+        continue
+    for f in fs:
+        if f.endswith((".h", ".c", ".cpp")):
+            actual.setdefault(f.lower(), []).append((f, dp))
+
+inc_re = re.compile(r'#\s*include\s+["<]([^">]+)[">]')
+wanted = set()
+for dp, _, fs in os.walk(SRC):
+    if os.sep + ".git" in dp:
+        continue
+    for f in fs:
+        if not f.endswith((".h", ".c", ".cpp")):
+            continue
+        try:
+            for line in open(os.path.join(dp, f), encoding="utf-8", errors="ignore"):
+                m = inc_re.search(line)
+                if not m:
+                    continue
+                base = os.path.basename(m.group(1))
+                lb = base.lower()
+                if lb in actual and base != actual[lb][0][0]:
+                    wanted.add(base)
+        except OSError:
+            pass
+
+created = 0
+for base in sorted(wanted):
+    real_base, real_dir = actual[base.lower()][0]
+    link = os.path.join(real_dir, base)
+    if os.path.lexists(link):
+        continue
+    os.symlink(real_base, link)
+    created += 1
+    print(f"  {os.path.relpath(link, SRC)} -> {real_base}")
+
+# Misspelled directory: includes reference Monsters/PlaguesSithra/... (real: PlagueSsithra).
+mons = os.path.join(SRC, "game", "src", "Monsters")
+real_dir = os.path.join(mons, "PlagueSsithra")
+link_dir = os.path.join(mons, "PlaguesSithra")
+if os.path.isdir(real_dir) and not os.path.lexists(link_dir):
+    os.symlink("PlagueSsithra", link_dir)
+    created += 1
+    print(f"  Monsters/PlaguesSithra -> PlagueSsithra")
+
+print(f"Created {created} case-correct symlink(s).")

--- a/src/linux/launcher_main.c
+++ b/src/linux/launcher_main.c
@@ -1,0 +1,12 @@
+//
+// launcher_main.c -- Heretic2R launcher (Linux). Replaces win32 WinMain.
+//
+// Copyright 1998 Raven Software
+//
+
+#include "sys_unix.h"
+
+int main(int argc, char** argv)
+{
+	return Quake2Main_Unix(argc, argv);
+}

--- a/src/linux/linux_compat.h
+++ b/src/linux/linux_compat.h
@@ -25,6 +25,7 @@
 #include <time.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <dirent.h>
 #include <dlfcn.h>
 
 // ---------------------------------------------------------------------------
@@ -89,6 +90,57 @@ int       Sys_dlclose(void* handle);
 
 // Windows multimedia timer (ms since startup); implemented in src/linux/q_shunix.c.
 unsigned int timeGetTime(void);
+
+// Resolve the final component of a path case-insensitively. Windows game data
+// (e.g. Bumper.smk, track02.ogg) may differ in case from what the engine/config
+// requests; on case-sensitive Linux that breaks direct fopen()s done by libraries
+// (libsmacker, stb_vorbis). If 'in' exists as-is it is copied through; otherwise
+// the containing directory is scanned for a case-insensitive filename match.
+// 'out' may alias 'in'. Returns 'out'.
+static inline char* H2_ResolveCasePath(const char* in, char* out, size_t outsize)
+{
+    struct stat st;
+    if (stat(in, &st) == 0)
+    {
+        if (out != in) { snprintf(out, outsize, "%s", in); }
+        return out;
+    }
+
+    const char* slash = strrchr(in, '/');
+    const char* fname = (slash != NULL) ? slash + 1 : in;
+
+    char dir[1024];
+    if (slash != NULL)
+    {
+        size_t dl = (size_t)(slash - in);
+        if (dl >= sizeof(dir)) dl = sizeof(dir) - 1;
+        memcpy(dir, in, dl);
+        dir[dl] = '\0';
+    }
+    else
+    {
+        dir[0] = '.'; dir[1] = '\0';
+    }
+
+    DIR* d = opendir(dir);
+    if (d != NULL)
+    {
+        struct dirent* e;
+        while ((e = readdir(d)) != NULL)
+        {
+            if (strcasecmp(e->d_name, fname) == 0)
+            {
+                snprintf(out, outsize, "%s/%s", dir, e->d_name);
+                closedir(d);
+                return out;
+            }
+        }
+        closedir(d);
+    }
+
+    if (out != in) { snprintf(out, outsize, "%s", in); }
+    return out;
+}
 
 #define LoadLibrary(name)         Sys_dlopen(name)
 #define FreeLibrary(h)            Sys_dlclose(h)

--- a/src/linux/linux_compat.h
+++ b/src/linux/linux_compat.h
@@ -1,0 +1,264 @@
+//
+// linux_compat.h -- Windows/MSVC compatibility shim for building Heretic2R on Linux.
+//
+// Force-included (via -include) before every translation unit by the CMake build.
+// Provides the MSVC "secure CRT" (*_s) string functions, the handful of Win32 types
+// and APIs the engine references outside its platform layer, and maps MSVC keywords
+// (__declspec, __forceinline, ...) onto their GCC/Clang equivalents.
+//
+// Copyright 2026 (Linux port)
+//
+
+#pragma once
+
+#ifndef _WIN32
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>   // strcasecmp / strncasecmp
+#include <ctype.h>
+#include <limits.h>
+#include <time.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <dlfcn.h>
+
+// ---------------------------------------------------------------------------
+// MSVC keywords / calling conventions.
+// ---------------------------------------------------------------------------
+
+// __declspec(dllexport) / dllimport / noreturn / align(n).
+// On a Linux .so all extern symbols are exported by default, so dllexport/dllimport
+// reduce to a default-visibility no-op; noreturn maps to the GCC attribute.
+#define H2_DECLSPEC_dllexport __attribute__((visibility("default")))
+#define H2_DECLSPEC_dllimport
+#define H2_DECLSPEC_noreturn  __attribute__((noreturn))
+#define __declspec(x)         H2_DECLSPEC_##x
+
+#ifndef WINAPI
+#define WINAPI
+#endif
+#ifndef APIENTRY
+#define APIENTRY
+#endif
+#define __cdecl
+#define __fastcall
+#define __stdcall
+#define __forceinline inline
+#ifndef __inline
+#define __inline inline
+#endif
+#ifndef _inline
+#define _inline inline
+#endif
+
+// ---------------------------------------------------------------------------
+// Win32 types / handles referenced in cross-platform engine code.
+// ---------------------------------------------------------------------------
+
+typedef void*          HINSTANCE;
+typedef void*          HMODULE;
+typedef void*          HANDLE;
+typedef void*          HWND;
+typedef int            BOOL;
+typedef uint32_t       DWORD;
+typedef unsigned char  BYTE;
+typedef unsigned short WORD;
+typedef const char*    LPCSTR;
+typedef char*          LPSTR;
+typedef void*          LPVOID;
+
+#ifndef MB_OK
+#define MB_OK          0x0
+#define MB_ICONWARNING 0x0
+#define MB_ICONERROR   0x0
+#endif
+
+// ---------------------------------------------------------------------------
+// Win32 APIs used outside the platform layer.
+// ---------------------------------------------------------------------------
+
+// Dynamic library loading (see src/linux/dll_unix.c). LoadLibrary appends/translates
+// the ".so" extension; FreeLibrary returns non-zero on success (opposite of dlclose).
+HINSTANCE Sys_dlopen(const char* name);
+int       Sys_dlclose(void* handle);
+
+// Windows multimedia timer (ms since startup); implemented in src/linux/q_shunix.c.
+unsigned int timeGetTime(void);
+
+#define LoadLibrary(name)         Sys_dlopen(name)
+#define FreeLibrary(h)            Sys_dlclose(h)
+#define GetProcAddress(h, name)   dlsym((h), (name))
+
+#define MessageBox(hwnd, text, caption, type) \
+    ((void)fprintf(stderr, "[%s] %s\n", (caption), (text)), 0)
+#define OutputDebugString(s)      ((void)fputs((s), stderr))
+
+#define _mkdir(path)              mkdir((path), 0755)
+
+// ---------------------------------------------------------------------------
+// MSVC "secure CRT" string/IO functions (truncating, bounds-checked variants).
+// Return 0 on success like the originals; callers that ignore the result are fine.
+// ---------------------------------------------------------------------------
+
+static inline int h2_strcpy_s(char* dst, size_t size, const char* src)
+{
+    if (dst == NULL || size == 0) return 22; // EINVAL
+    if (src == NULL) { dst[0] = '\0'; return 22; }
+    size_t len = strlen(src);
+    if (len >= size) { dst[0] = '\0'; return 34; } // ERANGE
+    memcpy(dst, src, len + 1);
+    return 0;
+}
+
+static inline int h2_strncpy_s(char* dst, size_t size, const char* src, size_t count)
+{
+    if (dst == NULL || size == 0) return 22;
+    if (src == NULL) { dst[0] = '\0'; return 22; }
+    size_t len = strnlen(src, count);
+    if (len >= size) { dst[0] = '\0'; return 34; }
+    memcpy(dst, src, len);
+    dst[len] = '\0';
+    return 0;
+}
+
+static inline int h2_strcat_s(char* dst, size_t size, const char* src)
+{
+    if (dst == NULL || size == 0 || src == NULL) return 22;
+    size_t dlen = strnlen(dst, size);
+    if (dlen == size) return 22; // not null-terminated
+    size_t slen = strlen(src);
+    if (dlen + slen >= size) return 34;
+    memcpy(dst + dlen, src, slen + 1);
+    return 0;
+}
+
+static inline int h2_strncat_s(char* dst, size_t size, const char* src, size_t count)
+{
+    if (dst == NULL || size == 0 || src == NULL) return 22;
+    size_t dlen = strnlen(dst, size);
+    if (dlen == size) return 22;
+    size_t slen = strnlen(src, count);
+    if (dlen + slen >= size) return 34;
+    memcpy(dst + dlen, src, slen);
+    dst[dlen + slen] = '\0';
+    return 0;
+}
+
+static inline int h2_memcpy_s(void* dst, size_t dstsize, const void* src, size_t count)
+{
+    if (dst == NULL) return 22;
+    if (count == 0) return 0;
+    if (src == NULL || count > dstsize) { memset(dst, 0, dstsize); return 22; }
+    memcpy(dst, src, count);
+    return 0;
+}
+
+static inline int h2_fopen_s(FILE** f, const char* name, const char* mode)
+{
+    if (f == NULL) return 22;
+    *f = fopen(name, mode);
+    return (*f != NULL) ? 0 : 2; // ENOENT-ish
+}
+
+static inline int h2_memmove_s(void* dst, size_t dstsize, const void* src, size_t count)
+{
+    if (dst == NULL) return 22;
+    if (count == 0) return 0;
+    if (src == NULL || count > dstsize) { memset(dst, 0, dstsize); return 22; }
+    memmove(dst, src, count);
+    return 0;
+}
+
+// MSVC fread_s(buf, bufsize, elemsize, count, stream) returns elements read, like fread.
+static inline size_t h2_fread_s(void* buf, size_t bufsize, size_t elemsize, size_t count, FILE* stream)
+{
+    (void)bufsize;
+    return fread(buf, elemsize, count, stream);
+}
+
+#ifdef __cplusplus
+// C++: MSVC's secure-CRT functions have array-deducing template overloads, e.g.
+// strcpy_s(dst_array, src) with the size inferred. Provide those plus the explicit
+// (ptr, size, ...) overloads as functions, not macros, so both call forms resolve.
+static inline int strcpy_s(char* d, size_t n, const char* s) { return h2_strcpy_s(d, n, s); }
+template<size_t N> static inline int strcpy_s(char (&d)[N], const char* s) { return h2_strcpy_s(d, N, s); }
+
+static inline int strncpy_s(char* d, size_t n, const char* s, size_t c) { return h2_strncpy_s(d, n, s, c); }
+template<size_t N> static inline int strncpy_s(char (&d)[N], const char* s, size_t c) { return h2_strncpy_s(d, N, s, c); }
+
+static inline int strcat_s(char* d, size_t n, const char* s) { return h2_strcat_s(d, n, s); }
+template<size_t N> static inline int strcat_s(char (&d)[N], const char* s) { return h2_strcat_s(d, N, s); }
+
+static inline int strncat_s(char* d, size_t n, const char* s, size_t c) { return h2_strncat_s(d, n, s, c); }
+template<size_t N> static inline int strncat_s(char (&d)[N], const char* s, size_t c) { return h2_strncat_s(d, N, s, c); }
+
+static inline int fopen_s(FILE** f, const char* n, const char* m) { return h2_fopen_s(f, n, m); }
+static inline int memcpy_s(void* d, size_t dn, const void* s, size_t c) { return h2_memcpy_s(d, dn, s, c); }
+static inline int memmove_s(void* d, size_t dn, const void* s, size_t c) { return h2_memmove_s(d, dn, s, c); }
+static inline size_t fread_s(void* b, size_t bs, size_t es, size_t c, FILE* f) { return h2_fread_s(b, bs, es, c, f); }
+
+static inline int sprintf_s(char* d, size_t n, const char* fmt, ...)
+{ va_list ap; va_start(ap, fmt); int r = vsnprintf(d, n, fmt, ap); va_end(ap); return r; }
+template<size_t N, typename... A> static inline int sprintf_s(char (&d)[N], const char* fmt, A... a)
+{ return snprintf(d, N, fmt, a...); }
+
+static inline int vsprintf_s(char* d, size_t n, const char* fmt, va_list ap) { return vsnprintf(d, n, fmt, ap); }
+template<size_t N> static inline int vsprintf_s(char (&d)[N], const char* fmt, va_list ap) { return vsnprintf(d, N, fmt, ap); }
+
+#define _snprintf   snprintf
+#define _vsnprintf  vsnprintf
+#else
+#define strcpy_s(dst, size, src)        h2_strcpy_s((dst), (size), (src))
+#define strncpy_s(dst, size, src, cnt)  h2_strncpy_s((dst), (size), (src), (cnt))
+#define strcat_s(dst, size, src)        h2_strcat_s((dst), (size), (src))
+#define strncat_s(dst, size, src, cnt)  h2_strncat_s((dst), (size), (src), (cnt))
+#define fopen_s(fp, name, mode)         h2_fopen_s((fp), (name), (mode))
+#define memcpy_s(dst, dsize, src, cnt)  h2_memcpy_s((dst), (dsize), (src), (cnt))
+#define memmove_s(dst, dsize, src, cnt) h2_memmove_s((dst), (dsize), (src), (cnt))
+#define fread_s(buf, bsz, esz, cnt, fp) h2_fread_s((buf), (bsz), (esz), (cnt), (fp))
+
+// Formatted output: MSVC's *_s variants truncate and null-terminate like snprintf.
+#define sprintf_s(buf, size, ...)       snprintf((buf), (size), __VA_ARGS__)
+#define _snprintf_s(buf, size, cnt, ...) snprintf((buf), (size), __VA_ARGS__)
+#define vsprintf_s(buf, size, fmt, ap)  vsnprintf((buf), (size), (fmt), (ap))
+#define vsnprintf_s(buf, size, cnt, fmt, ap) vsnprintf((buf), (size), (fmt), (ap))
+#define _vsnprintf                      vsnprintf
+#define _snprintf                       snprintf
+#endif
+
+// All sscanf_s uses in the tree are numeric (%x/%u/%i/%f) with no %s/%c/%[,
+// so the MSVC size arguments are absent and a direct mapping is safe.
+#define sscanf_s                        sscanf
+
+// strtok_s(str, delim, ctx) is identical to POSIX strtok_r.
+#define strtok_s(str, delim, ctx)       strtok_r((str), (delim), (ctx))
+
+// localtime_s(result, time) <-> POSIX localtime_r(time, result) (arguments swapped).
+#define localtime_s(tm_out, time_in)    (localtime_r((time_in), (tm_out)) ? 0 : 22)
+#define gmtime_s(tm_out, time_in)       (gmtime_r((time_in), (tm_out)) ? 0 : 22)
+
+// Misc MSVC CRT spellings.
+// MSVC provides these as macros via <stdlib.h>/<windef.h>; the engine uses them.
+// NOT in C++: the function-like macros would wreck STL headers (std::min, etc.).
+// C++ translation units should use std::min/std::max instead.
+#ifndef __cplusplus
+#ifndef max
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+#ifndef min
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+#endif
+
+#define _stricmp                        strcasecmp
+#define stricmp                         strcasecmp
+#define _strnicmp                       strncasecmp
+#define strnicmp                        strncasecmp
+#define _strdup                         strdup
+
+#endif // !_WIN32

--- a/src/linux/net_udp.c
+++ b/src/linux/net_udp.c
@@ -1,0 +1,566 @@
+//
+// net_udp.c -- Linux BSD-sockets networking, ported from win32/net_wins.c.
+//
+// IPX (NA_IPX / NA_BROADCAST_IPX) is a dead protocol and is not supported on Linux;
+// those code paths are stubbed out. IP + loopback (single-player and modern
+// multiplayer) are fully functional.
+//
+// Copyright 1998 Raven Software
+//
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include "qcommon.h"
+#include "Random.h"
+
+#define MAX_LOOPBACK	4
+
+typedef struct
+{
+	byte data[MAX_MSGLEN];
+	int datalen;
+} loopmsg_t;
+
+typedef struct // H2
+{
+	byte data[MAX_MSGLEN];
+	int datalen;
+	uint timestamp;
+	qboolean is_free;
+} loopmsg2_t;
+
+typedef struct
+{
+	loopmsg_t msgs[MAX_LOOPBACK];
+	int get;
+	int send;
+} loopback_t;
+
+#define NUM_SOCKETS			3
+#define NUM_LOOPMESSAGES	20
+
+static loopback_t loopbacks[NUM_SOCKETS];
+static loopmsg2_t loopmessages[NUM_SOCKETS][NUM_LOOPMESSAGES]; // H2
+static int ip_sockets[NUM_SOCKETS];
+
+static cvar_t* net_shownet;
+static cvar_t* noudp;
+static cvar_t* noipx;
+
+static void NetadrToSockadr(const netadr_t* a, struct sockaddr* s)
+{
+	memset(s, 0, sizeof(*s));
+
+	switch (a->type)
+	{
+		case NA_BROADCAST:
+		{
+			struct sockaddr_in* s_in = (struct sockaddr_in*)s;
+			s_in->sin_family = AF_INET;
+			s_in->sin_port = a->port;
+			s_in->sin_addr.s_addr = INADDR_BROADCAST;
+		} break;
+
+		case NA_IP:
+		{
+			struct sockaddr_in* s_in = (struct sockaddr_in*)s;
+			s_in->sin_family = AF_INET;
+			s_in->sin_addr.s_addr = *(int*)&a->ip;
+			s_in->sin_port = a->port;
+		} break;
+
+		default:
+			break;
+	}
+}
+
+static void SockadrToNetadr(struct sockaddr* s, netadr_t* a)
+{
+	if (s->sa_family == AF_INET)
+	{
+		const struct sockaddr_in* s_in = (struct sockaddr_in*)s;
+		a->type = NA_IP;
+		memcpy(a->ip, &s_in->sin_addr.s_addr, sizeof(s_in->sin_addr.s_addr));
+		a->port = s_in->sin_port;
+	}
+}
+
+// Q2 counterpart
+qboolean NET_CompareAdr(const netadr_t* a, const netadr_t* b)
+{
+	if (a->type != b->type)
+		return false;
+
+	switch (a->type)
+	{
+		case NA_LOOPBACK:
+			return true;
+
+		case NA_IP:
+			return (a->port == b->port && memcmp(a->ip, b->ip, 4) == 0);
+
+		case NA_IPX:
+			return (a->port == b->port && memcmp(a->ipx, b->ipx, 10) == 0);
+
+		default:
+			return false;
+	}
+}
+
+// Q2 counterpart
+// Compares without the port.
+qboolean NET_CompareBaseAdr(const netadr_t* a, const netadr_t* b)
+{
+	if (a->type != b->type)
+		return false;
+
+	switch (a->type)
+	{
+		case NA_LOOPBACK:
+			return true;
+
+		case NA_IP:
+			return (memcmp(a->ip, b->ip, 4) == 0);
+
+		case NA_IPX:
+			return (memcmp(a->ipx, b->ipx, 10) == 0);
+
+		default:
+			return false;
+	}
+}
+
+// Q2 counterpart
+static qboolean NET_StringToSockaddr(const char* s, struct sockaddr* sadr)
+{
+	memset(sadr, 0, sizeof(*sadr));
+
+	struct sockaddr_in* sa_in = (struct sockaddr_in*)sadr;
+
+	sa_in->sin_family = AF_INET;
+	sa_in->sin_port = 0;
+
+	char copy[128];
+	strcpy_s(copy, sizeof(copy), s);
+
+	// Strip off a trailing :port if present.
+	for (char* colon = copy; *colon != 0; colon++)
+	{
+		if (*colon == ':')
+		{
+			*colon = 0;
+			sa_in->sin_port = htons((ushort)Q_atoi(colon + 1));
+		}
+	}
+
+	if (copy[0] >= '0' && copy[0] <= '9')
+	{
+		sa_in->sin_addr.s_addr = inet_addr(copy);
+	}
+	else
+	{
+		const struct hostent* h = gethostbyname(copy);
+		if (h == NULL)
+			return false;
+
+		sa_in->sin_addr.s_addr = *(int*)h->h_addr_list[0];
+	}
+
+	return true;
+}
+
+// Q2 counterpart
+char* NET_AdrToString(const netadr_t* a)
+{
+	static char s[64];
+
+	switch (a->type)
+	{
+		case NA_LOOPBACK:
+			Com_sprintf(s, sizeof(s), "loopback");
+			break;
+
+		case NA_IP:
+			Com_sprintf(s, sizeof(s), "%i.%i.%i.%i:%i", a->ip[0], a->ip[1], a->ip[2], a->ip[3], ntohs(a->port));
+			break;
+
+		default:
+			Com_sprintf(s, sizeof(s), "%02x%02x%02x%02x:%02x%02x%02x%02x%02x%02x:%i", a->ipx[0], a->ipx[1], a->ipx[2], a->ipx[3], a->ipx[4], a->ipx[5], a->ipx[6], a->ipx[7], a->ipx[8], a->ipx[9], ntohs(a->port));
+			break;
+	}
+
+	return s;
+}
+
+// Q2 counterpart
+// Input string examples: 'localhost', 'idnewt', 'idnewt:28000', '192.246.40.70', '192.246.40.70:28000'.
+qboolean NET_StringToAdr(const char* s, netadr_t* a)
+{
+	struct sockaddr sadr;
+
+	if (strcmp(s, "localhost") == 0)
+	{
+		memset(a, 0, sizeof(netadr_t));
+		a->type = NA_LOOPBACK;
+
+		return true;
+	}
+
+	if (NET_StringToSockaddr(s, &sadr))
+	{
+		SockadrToNetadr(&sadr, a);
+		return true;
+	}
+
+	return false;
+}
+
+static char* NET_ErrorString(void)
+{
+	return strerror(errno);
+}
+
+// Q2 counterpart.
+qboolean NET_IsLocalAddress(const netadr_t* a)
+{
+	return a->type == NA_LOOPBACK;
+}
+
+#pragma region ========================== LOOPBACK BUFFERS FOR LOCAL PLAYER ==========================
+
+static qboolean NET_GetLoopPacket(const netsrc_t sock, netadr_t* n_from, sizebuf_t* n_message)
+{
+	// H2: emulate net latency.
+	if (net_latency->value > 0.0f && net_latency->value < 2000.0f)
+	{
+		const uint time = timeGetTime();
+		loopmsg2_t* msg = &loopmessages[sock][0];
+
+		for (int i = 0; i < NUM_LOOPMESSAGES; i++, msg++)
+		{
+			if (msg->is_free && msg->timestamp < time)
+			{
+				msg->is_free = false;
+
+				memcpy(n_message->data, msg->data, msg->datalen);
+				n_message->cursize = msg->datalen;
+
+				memset(n_from, 0, sizeof(*n_from));
+				n_from->type = NA_LOOPBACK;
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	// Q2 logic:
+	loopback_t* loop = &loopbacks[sock];
+
+	if (loop->send - loop->get > MAX_LOOPBACK)
+		loop->get = loop->send - MAX_LOOPBACK;
+
+	if (loop->get >= loop->send)
+		return false;
+
+	const int i = loop->get & (MAX_LOOPBACK - 1);
+	loop->get++;
+
+	memcpy(n_message->data, loop->msgs[i].data, loop->msgs[i].datalen);
+	n_message->cursize = loop->msgs[i].datalen;
+	memset(n_from, 0, sizeof(*n_from));
+	n_from->type = NA_LOOPBACK;
+
+	return true;
+}
+
+static void NET_SendLoopPacket(const netsrc_t sock, const int length, const void* data)
+{
+	// H2: emulate net latency.
+	if (net_latency->value > 0.0f && net_latency->value < 2000.0f)
+	{
+		const uint time = timeGetTime();
+		loopmsg2_t* msg = &loopmessages[sock ^ 1][0];
+
+		for (int i = 0; i < NUM_LOOPMESSAGES; i++, msg++)
+		{
+			if (!msg->is_free)
+			{
+				msg->is_free = true;
+				const float nl = net_latency->value;
+				msg->timestamp = time + (int)(nl + flrand(-nl * 0.25f, nl * 0.25f));
+
+				memcpy(msg, data, length);
+				msg->datalen = length;
+			}
+		}
+
+		return;
+	}
+
+	// Original Q2 logic:
+	loopback_t* loop = &loopbacks[sock ^ 1];
+	const int index = loop->send & (MAX_LOOPBACK - 1);
+	loop->send++;
+
+	memcpy(loop->msgs[index].data, data, length);
+	loop->msgs[index].datalen = length;
+}
+
+#pragma endregion
+
+qboolean NET_GetPacket(const netsrc_t sock, netadr_t* n_from, sizebuf_t* n_message)
+{
+	struct sockaddr from;
+
+	if (NET_GetLoopPacket(sock, n_from, n_message))
+	{
+		// H2: emulate packet loss.
+		if (net_receiverate->value > 0.0f && net_receiverate->value < 1.0f && flrand(0.0f, 1.0f) > net_receiverate->value)
+		{
+			n_message->cursize = 0;
+			return false;
+		}
+
+		return true;
+	}
+
+	const int net_socket = ip_sockets[sock];
+	if (net_socket == 0)
+		return false;
+
+	socklen_t fromlen = sizeof(from);
+	const int ret = recvfrom(net_socket, (char*)n_message->data, n_message->maxsize, 0, &from, &fromlen);
+
+	if (ret == -1)
+	{
+		if (errno != EWOULDBLOCK && errno != EAGAIN)
+		{
+			// Let dedicated servers continue after errors.
+			if ((int)dedicated->value)
+				Com_Printf("NET_GetPacket: %s from %s\n", NET_ErrorString(), NET_AdrToString(n_from));
+			else
+				Com_Error(ERR_DROP, "NET_GetPacket: %s from %s", NET_ErrorString(), NET_AdrToString(n_from));
+		}
+
+		return false;
+	}
+
+	SockadrToNetadr(&from, n_from);
+
+	if (ret == n_message->maxsize)
+	{
+		Com_Printf("Oversize packet from %s\n", NET_AdrToString(n_from));
+		return false;
+	}
+
+	// H2: emulate packet loss.
+	if (net_receiverate->value > 0.0f && net_receiverate->value < 1.0f && flrand(0.0f, 1.0f) > net_receiverate->value)
+	{
+		n_message->cursize = 0;
+		return false;
+	}
+
+	n_message->cursize = ret;
+	return true;
+}
+
+void NET_SendPacket(const netsrc_t sock, const int length, const void* data, const netadr_t* to)
+{
+	struct sockaddr addr;
+
+	// H2: emulate packet loss.
+	if (net_sendrate->value > 0.0f && net_sendrate->value < 1.0f && net_sendrate->value < flrand(0.0f, 1.0f))
+		return;
+
+	switch (to->type)
+	{
+		case NA_LOOPBACK:
+			NET_SendLoopPacket(sock, length, data);
+			return;
+
+		case NA_IP:
+		case NA_BROADCAST:
+			break;
+
+		default:
+			Com_Error(ERR_FATAL, "NET_SendPacket: bad address type");
+			return;
+	}
+
+	const int net_socket = ip_sockets[sock];
+	if (net_socket == 0)
+		return;
+
+	NetadrToSockadr(to, &addr);
+
+	if (sendto(net_socket, data, length, 0, &addr, sizeof(addr)) == -1)
+	{
+		const int err = errno;
+
+		// Wouldblock is silent.
+		if (err == EWOULDBLOCK || err == EAGAIN)
+			return;
+
+		// Some PPP links don't allow broadcasts.
+		if (err == EADDRNOTAVAIL && to->type == NA_BROADCAST)
+			return;
+
+		// Let dedicated servers continue after errors.
+		if ((int)dedicated->value)
+			Com_Printf("NET_SendPacket ERROR: %s\n", NET_ErrorString());
+		else if (err == EADDRNOTAVAIL)
+			Com_DPrintf("NET_SendPacket Warning: %s : %s\n", NET_ErrorString(), NET_AdrToString(to));
+		else
+			Com_Error(ERR_DROP, "NET_SendPacket ERROR: %s\n", NET_ErrorString());
+	}
+}
+
+// Q2 counterpart
+static int NET_IPSocket(const char* net_interface, const int port)
+{
+	const int newsocket = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (newsocket < 0)
+	{
+		if (errno != EAFNOSUPPORT)
+			Com_Printf("WARNING: UDP_OpenSocket: socket: %s\n", NET_ErrorString());
+
+		return 0;
+	}
+
+	// Make it non-blocking.
+	if (fcntl(newsocket, F_SETFL, fcntl(newsocket, F_GETFL, 0) | O_NONBLOCK) == -1)
+	{
+		Com_Printf("WARNING: UDP_OpenSocket: fcntl O_NONBLOCK: %s\n", NET_ErrorString());
+		close(newsocket);
+		return 0;
+	}
+
+	// Make it broadcast capable.
+	int optval = 1;
+	if (setsockopt(newsocket, SOL_SOCKET, SO_BROADCAST, (char*)&optval, sizeof(optval)) == -1)
+	{
+		Com_Printf("WARNING: UDP_OpenSocket: setsockopt SO_BROADCAST: %s\n", NET_ErrorString());
+		close(newsocket);
+		return 0;
+	}
+
+	struct sockaddr_in address;
+	memset(&address, 0, sizeof(address));
+
+	if (net_interface == NULL || net_interface[0] == 0 || Q_stricmp(net_interface, "localhost") == 0)
+		address.sin_addr.s_addr = INADDR_ANY;
+	else
+		NET_StringToSockaddr(net_interface, (struct sockaddr*)&address);
+
+	if (port == PORT_ANY)
+		address.sin_port = 0;
+	else
+		address.sin_port = htons((ushort)port);
+
+	address.sin_family = AF_INET;
+
+	if (bind(newsocket, (struct sockaddr*)&address, sizeof(address)) == -1)
+	{
+		Com_Printf("WARNING: UDP_OpenSocket: bind: %s\n", NET_ErrorString());
+		close(newsocket);
+
+		return 0;
+	}
+
+	return newsocket;
+}
+
+static void NET_OpenIP(void)
+{
+	const cvar_t* ip = Cvar_Get("ip", "localhost", CVAR_NOSET);
+	const qboolean is_dedicated = Cvar_IsSet("dedicated");
+
+	if (ip_sockets[NS_SERVER] == 0)
+	{
+		int port = (int)Cvar_Get("ip_hostport", "0", CVAR_NOSET)->value;
+		if (port == 0)
+		{
+			port = (int)Cvar_Get("hostport", "0", CVAR_NOSET)->value;
+			if (port == 0)
+				port = (int)Cvar_Get("port", va("%i", PORT_SERVER), CVAR_NOSET)->value;
+		}
+
+		ip_sockets[NS_SERVER] = NET_IPSocket(ip->string, port);
+		if (is_dedicated && ip_sockets[NS_SERVER] == 0)
+			Com_Error(ERR_FATAL, "Couldn't allocate dedicated server IP port");
+	}
+
+	// Dedicated servers don't need client ports.
+	if (is_dedicated)
+		return;
+
+	if (ip_sockets[NS_CLIENT] == 0)
+	{
+		int port = (int)Cvar_Get("ip_clientport", "0", CVAR_NOSET)->value;
+		if (port == 0)
+		{
+			port = (int)Cvar_Get("clientport", va("%i", PORT_CLIENT), CVAR_NOSET)->value;
+			if (port == 0)
+				port = PORT_ANY;
+		}
+
+		ip_sockets[NS_CLIENT] = NET_IPSocket(ip->string, port);
+		if (ip_sockets[NS_CLIENT] == 0)
+			ip_sockets[NS_CLIENT] = NET_IPSocket(ip->string, PORT_ANY);
+	}
+}
+
+// A single player game will only use the loopback code.
+void NET_Config(const qboolean multiplayer)
+{
+	static qboolean old_config;
+
+	if (old_config == multiplayer)
+		return;
+
+	old_config = multiplayer;
+
+	if (multiplayer)
+	{
+		// Open sockets. (IPX is unsupported on Linux.)
+		if (!(int)noudp->value)
+			NET_OpenIP();
+	}
+	else
+	{
+		// Shut down any existing sockets.
+		for (int i = 0; i < NUM_SOCKETS; i++)
+		{
+			if (ip_sockets[i] != 0)
+			{
+				close(ip_sockets[i]);
+				ip_sockets[i] = 0;
+			}
+		}
+	}
+}
+
+void NET_Init(void)
+{
+	Com_Printf("UDP networking initialized\n");
+
+	noudp = Cvar_Get("noudp", "0", CVAR_NOSET);
+	noipx = Cvar_Get("noipx", "1", CVAR_NOSET); // IPX unsupported on Linux.
+
+	net_shownet = Cvar_Get("net_shownet", "0", 0);
+}
+
+// Q2 counterpart
+void NET_Shutdown(void)
+{
+	NET_Config(false); // Close sockets.
+}

--- a/src/linux/q_shunix.c
+++ b/src/linux/q_shunix.c
@@ -8,7 +8,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <time.h>
-#include <glob.h>
+#include <dirent.h>
+#include <fnmatch.h>
 #include "qcommon.h"
 
 int curtime;
@@ -60,9 +61,9 @@ qboolean Sys_IsFile(const char* path) // YQ2
 #pragma region ========================== FIND FILES ==========================
 
 static char findpath[MAX_OSPATH];
-static glob_t find_glob;
-static size_t find_index;
-static qboolean find_active;
+static char find_dir[MAX_OSPATH];
+static char find_pattern[MAX_OSPATH];
+static DIR* find_dirp;
 
 static qboolean Sys_FindAttrMatch(const char* path, const uint musthave, const uint canthave)
 {
@@ -81,21 +82,35 @@ static qboolean Sys_FindAttrMatch(const char* path, const uint musthave, const u
 	return true;
 }
 
-// Q2 counterpart
+// Q2 counterpart. Uses opendir()/fnmatch() rather than glob() so that matching is
+// case-insensitive (FNM_CASEFOLD): Windows game data filenames often differ in case
+// from what the engine/config requests, which would otherwise fail on case-sensitive
+// Linux filesystems.
 char* Sys_FindFirst(const char* path, const uint musthave, const uint canthave)
 {
-	if (find_active)
+	if (find_dirp != NULL)
 		Sys_Error("Sys_FindFirst called without close");
 
-	if (glob(path, GLOB_NOSORT, NULL, &find_glob) != 0)
+	// Split the search pattern into a directory and a filename glob.
+	const char* slash = strrchr(path, '/');
+	if (slash != NULL)
 	{
-		globfree(&find_glob);
-		memset(&find_glob, 0, sizeof(find_glob));
-		return NULL;
+		size_t dir_len = (size_t)(slash - path);
+		if (dir_len >= sizeof(find_dir))
+			dir_len = sizeof(find_dir) - 1;
+		memcpy(find_dir, path, dir_len);
+		find_dir[dir_len] = '\0';
+		strcpy_s(find_pattern, sizeof(find_pattern), slash + 1);
+	}
+	else
+	{
+		strcpy_s(find_dir, sizeof(find_dir), ".");
+		strcpy_s(find_pattern, sizeof(find_pattern), path);
 	}
 
-	find_active = true;
-	find_index = 0;
+	find_dirp = opendir(find_dir);
+	if (find_dirp == NULL)
+		return NULL;
 
 	return Sys_FindNext(musthave, canthave);
 }
@@ -103,23 +118,24 @@ char* Sys_FindFirst(const char* path, const uint musthave, const uint canthave)
 // Q2 counterpart
 char* Sys_FindNext(const uint musthave, const uint canthave)
 {
-	if (!find_active)
+	if (find_dirp == NULL)
 		return NULL;
 
-	while (find_index < find_glob.gl_pathc)
+	const struct dirent* entry;
+	while ((entry = readdir(find_dirp)) != NULL)
 	{
-		const char* match = find_glob.gl_pathv[find_index++];
-
 		// Skip "." and ".." entries.
-		const char* name = strrchr(match, '/');
-		name = (name != NULL) ? name + 1 : match;
-		if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
+		if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
 			continue;
 
-		if (!Sys_FindAttrMatch(match, musthave, canthave))
+		if (fnmatch(find_pattern, entry->d_name, FNM_CASEFOLD) != 0)
 			continue;
 
-		strcpy_s(findpath, sizeof(findpath), match);
+		Com_sprintf(findpath, sizeof(findpath), "%s/%s", find_dir, entry->d_name);
+
+		if (!Sys_FindAttrMatch(findpath, musthave, canthave))
+			continue;
+
 		return findpath;
 	}
 
@@ -129,11 +145,10 @@ char* Sys_FindNext(const uint musthave, const uint canthave)
 // Q2 counterpart
 void Sys_FindClose(void)
 {
-	if (find_active)
+	if (find_dirp != NULL)
 	{
-		globfree(&find_glob);
-		memset(&find_glob, 0, sizeof(find_glob));
-		find_active = false;
+		closedir(find_dirp);
+		find_dirp = NULL;
 	}
 }
 

--- a/src/linux/q_shunix.c
+++ b/src/linux/q_shunix.c
@@ -1,0 +1,165 @@
+//
+// q_shunix.c -- Linux filesystem/time helpers, ported from win32/q_shwin.c.
+//
+// Copyright 1998 Raven Software
+//
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <time.h>
+#include <glob.h>
+#include "qcommon.h"
+
+int curtime;
+
+long long Sys_Microseconds(void) // YQ2
+{
+	static long long base = 0;
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+
+	long long now = (long long)ts.tv_sec * 1000000ll + ts.tv_nsec / 1000ll;
+
+	if (base == 0)
+		base = now - 1001;
+
+	return now - base;
+}
+
+// Windows multimedia timer replacement: milliseconds since startup.
+unsigned int timeGetTime(void)
+{
+	return (unsigned int)(Sys_Microseconds() / 1000ll);
+}
+
+void Sys_Nanosleep(const int nanosec)
+{
+	struct timespec t = { .tv_sec = nanosec / 1000000000, .tv_nsec = nanosec % 1000000000 };
+	nanosleep(&t, NULL);
+}
+
+// Q2 counterpart
+void Sys_Mkdir(const char* path)
+{
+	mkdir(path, 0755);
+}
+
+qboolean Sys_IsDir(const char* path) // YQ2
+{
+	struct stat st;
+	return (stat(path, &st) == 0 && S_ISDIR(st.st_mode));
+}
+
+qboolean Sys_IsFile(const char* path) // YQ2
+{
+	struct stat st;
+	return (stat(path, &st) == 0 && S_ISREG(st.st_mode));
+}
+
+#pragma region ========================== FIND FILES ==========================
+
+static char findpath[MAX_OSPATH];
+static glob_t find_glob;
+static size_t find_index;
+static qboolean find_active;
+
+static qboolean Sys_FindAttrMatch(const char* path, const uint musthave, const uint canthave)
+{
+	struct stat st;
+	if (stat(path, &st) != 0)
+		return false;
+
+	const qboolean is_dir = S_ISDIR(st.st_mode);
+
+	if (is_dir && (canthave & SFF_SUBDIR))
+		return false;
+
+	if ((musthave & SFF_SUBDIR) && !is_dir)
+		return false;
+
+	return true;
+}
+
+// Q2 counterpart
+char* Sys_FindFirst(const char* path, const uint musthave, const uint canthave)
+{
+	if (find_active)
+		Sys_Error("Sys_FindFirst called without close");
+
+	if (glob(path, GLOB_NOSORT, NULL, &find_glob) != 0)
+	{
+		globfree(&find_glob);
+		memset(&find_glob, 0, sizeof(find_glob));
+		return NULL;
+	}
+
+	find_active = true;
+	find_index = 0;
+
+	return Sys_FindNext(musthave, canthave);
+}
+
+// Q2 counterpart
+char* Sys_FindNext(const uint musthave, const uint canthave)
+{
+	if (!find_active)
+		return NULL;
+
+	while (find_index < find_glob.gl_pathc)
+	{
+		const char* match = find_glob.gl_pathv[find_index++];
+
+		// Skip "." and ".." entries.
+		const char* name = strrchr(match, '/');
+		name = (name != NULL) ? name + 1 : match;
+		if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
+			continue;
+
+		if (!Sys_FindAttrMatch(match, musthave, canthave))
+			continue;
+
+		strcpy_s(findpath, sizeof(findpath), match);
+		return findpath;
+	}
+
+	return NULL;
+}
+
+// Q2 counterpart
+void Sys_FindClose(void)
+{
+	if (find_active)
+	{
+		globfree(&find_glob);
+		memset(&find_glob, 0, sizeof(find_glob));
+		find_active = false;
+	}
+}
+
+#pragma endregion
+
+qboolean Sys_GetWorkingDir(char* buffer, const size_t len) // YQ2
+{
+	if (getcwd(buffer, len) != NULL)
+		return true;
+
+	buffer[0] = '\0';
+	return false;
+}
+
+//mxd. Get OS-specific path to create the Heretic2R userdir in.
+qboolean Sys_GetOSUserDir(char* buffer, const size_t len)
+{
+	const char* xdg = getenv("XDG_DATA_HOME");
+	const char* home = getenv("HOME");
+
+	if (xdg != NULL && xdg[0] != 0)
+		Com_sprintf(buffer, len, "%s", xdg);
+	else if (home != NULL && home[0] != 0)
+		Com_sprintf(buffer, len, "%s/.local/share", home);
+	else
+		buffer[0] = '\0';
+
+	return (buffer[0] != 0);
+}

--- a/src/linux/sys_unix.c
+++ b/src/linux/sys_unix.c
@@ -1,0 +1,202 @@
+//
+// sys_unix.c -- Linux system layer + main loop + DLL loading, ported from win32/sys_win.c.
+//
+// Copyright 1998 Raven Software
+//
+
+#include <dlfcn.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <errno.h>
+#include "sys_unix.h"
+#include "qcommon.h"
+#include "client/input.h"
+
+static char console_text[256];
+static int console_textlen;
+
+#pragma region ========================== SYSTEM IO ==========================
+
+H2R_NORETURN void Sys_Error(const char* error, ...)
+{
+	va_list argptr;
+	char text[1024];
+
+	va_start(argptr, error);
+	vsnprintf(text, sizeof(text), error, argptr);
+	va_end(argptr);
+
+	CL_Shutdown();
+
+	fprintf(stderr, "Error: %s\n", text);
+
+	exit(1);
+}
+
+H2R_NORETURN void Sys_Quit(void)
+{
+	CL_Shutdown();
+	exit(0);
+}
+
+#pragma endregion
+
+#pragma region ========================== DLL HANDLING ==========================
+
+// Translates a Windows-style module name to a Linux .so and dlopen()s it.
+// (Backs the LoadLibrary() macro in linux_compat.h.)
+void* Sys_dlopen(const char* name)
+{
+	char path[MAX_OSPATH];
+	strcpy_s(path, sizeof(path), name);
+
+	// Translate a trailing ".dll" to ".so", or append ".so" if the basename has no extension.
+	const size_t len = strlen(path);
+	if (len > 4 && Q_stricmp(path + len - 4, ".dll") == 0)
+	{
+		strcpy(path + len - 4, ".so");
+	}
+	else
+	{
+		char* base = strrchr(path, '/');
+		base = (base != NULL) ? base + 1 : path;
+		if (strchr(base, '.') == NULL)
+			strcat_s(path, sizeof(path), ".so");
+	}
+
+	// RTLD_NODELETE: keep the object mapped after dlclose(). Several modules
+	// (Client Effects, renderer/sound probes) follow a "load, fetch an API entry
+	// point, unload, then call that entry point later" pattern. On Windows the
+	// freed DLL's pages stay valid by luck; on Linux dlclose() unmaps the .so and
+	// the address gets reused (e.g. by SDL's libdbus), so the stale pointer jumps
+	// into unrelated code and crashes. NODELETE preserves the Windows behaviour.
+	const int flags = RTLD_NOW | RTLD_LOCAL | RTLD_NODELETE;
+
+	void* handle = dlopen(path, flags);
+
+	// If a bare name didn't resolve via the loader search path, try the cwd.
+	if (handle == NULL && strchr(path, '/') == NULL)
+	{
+		char local[MAX_OSPATH];
+		Com_sprintf(local, sizeof(local), "./%s", path);
+		handle = dlopen(local, flags);
+	}
+
+	if (handle == NULL)
+		Com_DDPrintf(2, "dlopen(%s) failed: %s\n", path, dlerror());
+
+	return handle;
+}
+
+// Backs the FreeLibrary() macro: returns non-zero on success (opposite of dlclose).
+int Sys_dlclose(void* handle)
+{
+	return (dlclose(handle) == 0);
+}
+
+void Sys_LoadGameDll(const char* dll_name, HINSTANCE* hinst, DWORD* checksum)
+{
+	char name[MAX_OSPATH];
+
+	// Run through the search paths.
+	char* path = NULL;
+	*hinst = NULL;
+
+	while (true)
+	{
+		path = FS_NextPath(path);
+		if (path == NULL)
+			break; // Couldn't find one anywhere.
+
+		Com_sprintf(name, sizeof(name), "%s/%s", path, dll_name);
+		*hinst = Sys_dlopen(name);
+		if (*hinst != NULL)
+			break;
+	}
+
+	if (*hinst == NULL)
+		Sys_Error("Failed to load %s", dll_name);
+
+	// PE checksum is meaningless on Linux; result is unused anyway.
+	*checksum = 0;
+
+	Com_DDPrintf(2, "dlopen (%s)\n", name);
+}
+
+void Sys_UnloadGameDll(const char* name, HINSTANCE* hinst)
+{
+	if (!Sys_dlclose(*hinst))
+		Sys_Error("Failed to unload %s", name);
+
+	*hinst = NULL;
+}
+
+#pragma endregion
+
+void Sys_Init(void)
+{
+	Set_Com_Printf(Com_Printf); // H2
+}
+
+// Q2 counterpart. Non-blocking dedicated-server console input.
+char* Sys_ConsoleInput(void)
+{
+	if (dedicated == NULL || !(int)dedicated->value)
+		return NULL;
+
+	fd_set fdset;
+	struct timeval timeout = { 0, 0 };
+
+	FD_ZERO(&fdset);
+	FD_SET(STDIN_FILENO, &fdset);
+
+	if (select(STDIN_FILENO + 1, &fdset, NULL, NULL, &timeout) == -1 || !FD_ISSET(STDIN_FILENO, &fdset))
+		return NULL;
+
+	const ssize_t len = read(STDIN_FILENO, console_text, sizeof(console_text) - 1);
+	if (len < 1)
+		return NULL;
+
+	console_text[len] = '\0';
+	if (len > 0 && console_text[len - 1] == '\n')
+		console_text[len - 1] = '\0';
+
+	console_textlen = 0;
+
+	return console_text;
+}
+
+// Q2 counterpart
+void Sys_ConsoleOutput(const char* string)
+{
+	if (dedicated == NULL || !(int)dedicated->value)
+		return;
+
+	fputs(string, stdout);
+	fflush(stdout);
+}
+
+int Quake2Main_Unix(int argc, char** argv)
+{
+	Qcommon_Init(argc, argv);
+
+	long long oldtime = Sys_Microseconds();
+
+	// The main game loop.
+	while (true)
+	{
+		const long long spintime = Sys_Microseconds();
+
+		// YQ2 busywait logic.
+		while (Sys_Microseconds() - spintime < 5)
+			Sys_CpuPause(); // Give the CPU a hint that this is a very tight spinloop.
+
+		const long long newtime = Sys_Microseconds();
+		curtime = (int)(newtime / 1000ll); // Save global time for network and input code.
+
+		Qcommon_Frame((int)(newtime - oldtime));
+		oldtime = newtime;
+	}
+
+	// Never gets here.
+}

--- a/src/linux/sys_unix.c
+++ b/src/linux/sys_unix.c
@@ -185,16 +185,22 @@ int Quake2Main_Unix(int argc, char** argv)
 	// The main game loop.
 	while (true)
 	{
-		const long long spintime = Sys_Microseconds();
-
-		// YQ2 busywait logic.
-		while (Sys_Microseconds() - spintime < 5)
-			Sys_CpuPause(); // Give the CPU a hint that this is a very tight spinloop.
-
 		const long long newtime = Sys_Microseconds();
+		const long long dt = newtime - oldtime;
+
+		// Cap the loop to ~1 kHz instead of busy-spinning a full CPU core (the
+		// original Win32/YQ2 path busy-waits, pinning a core at 100%). Qcommon_Frame
+		// applies its own (vid_maxfps) frame limiting, so it's enough to call it at
+		// 1 kHz; sleep the remainder of the 1 ms tick when we're ahead of schedule.
+		if (dt < 1000)
+		{
+			Sys_Nanosleep((int)((1000 - dt) * 1000ll)); // microseconds -> nanoseconds
+			continue;
+		}
+
 		curtime = (int)(newtime / 1000ll); // Save global time for network and input code.
 
-		Qcommon_Frame((int)(newtime - oldtime));
+		Qcommon_Frame((int)dt);
 		oldtime = newtime;
 	}
 

--- a/src/linux/sys_unix.h
+++ b/src/linux/sys_unix.h
@@ -1,0 +1,9 @@
+//
+// sys_unix.h -- Linux entry point exposed by quake2.so to the launcher.
+//
+// Copyright 2026 (Linux port)
+//
+
+#pragma once
+
+int Quake2Main_Unix(int argc, char** argv);

--- a/src/qcommon/Message.c
+++ b/src/qcommon/Message.c
@@ -27,12 +27,12 @@ size_t MSG_SetParms(SinglyLinkedList_t* parms, const char* format, va_list marke
 		switch (format[count])
 		{
 			case 'b':
-				parm.t_byte = va_arg(marker, byte);
+				parm.t_byte = (byte)va_arg(marker, int); // Linux: va_arg promotes byte->int
 				bytesParsed += sizeof(parm.t_byte);
 				break;
 
 			case 's':
-				parm.t_short = va_arg(marker, short);
+				parm.t_short = (short)va_arg(marker, int); // Linux: va_arg promotes short->int
 				bytesParsed += sizeof(parm.t_short);
 				break;
 

--- a/src/qcommon/SinglyLinkedList.h
+++ b/src/qcommon/SinglyLinkedList.h
@@ -9,7 +9,10 @@
 #include "H2Common.h"
 #include "GenericUnions.h"
 
-#define SLL_NODE_SIZE			8 //mxd. == sizeof(SinglyLinkedListNode_t)
+// SinglyLinkedListNode_t is { GenericUnion4_t data; node* next; }. GenericUnion4_t
+// holds a pointer, so on LP64 it is 8 bytes (not 4), making the node 16 bytes.
+// Hardcoded 8 was correct only for 32-bit; use the pointer-size-correct value.
+#define SLL_NODE_SIZE			(2 * sizeof(void*)) //mxd. == sizeof(SinglyLinkedListNode_t)
 #define SLL_NODE_BLOCK_SIZE		256 //mxd
 
 typedef struct SinglyLinkedList_s

--- a/src/qcommon/netmsg_write.c
+++ b/src/qcommon/netmsg_write.c
@@ -215,7 +215,7 @@ void ParseEffectToSizeBuf(sizebuf_t* sb, const char* format, va_list marker) // 
 		switch (*format)
 		{
 			case 'b':
-				MSG_WriteByte(sb, va_arg(marker, byte));
+				MSG_WriteByte(sb, (byte)va_arg(marker, int)); // Linux: va_arg promotes byte->int
 				break;
 
 			case 'd':
@@ -236,7 +236,7 @@ void ParseEffectToSizeBuf(sizebuf_t* sb, const char* format, va_list marker) // 
 				break;
 
 			case 's':
-				MSG_WriteShort(sb, va_arg(marker, short));
+				MSG_WriteShort(sb, (short)va_arg(marker, int)); // Linux: va_arg promotes short->int
 				break;
 
 			case 't':

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -31,6 +31,18 @@
 	#else
 		#define CPUSTRING	"x86"
 	#endif
+#else // Linux port
+	#ifdef NDEBUG
+		#define BUILDSTRING "RELEASE"
+	#else
+		#define BUILDSTRING "DEBUG"
+	#endif
+
+	#if defined(__x86_64__) || defined(__aarch64__) || defined(__LP64__)
+		#define CPUSTRING	"x64"
+	#else
+		#define CPUSTRING	"x86"
+	#endif
 #endif
 
 typedef struct sizebuf_s

--- a/src/quake2/src/client/cl_smk.c
+++ b/src/quake2/src/client/cl_smk.c
@@ -190,6 +190,9 @@ void SCR_PlayCinematic(const char* name)
 	}
 
 	sprintf_s(smk_filepath, sizeof(smk_filepath), "%s/video/%s", path, name); //mxd. sprintf -> sprintf_s
+#ifndef _WIN32
+	H2_ResolveCasePath(smk_filepath, smk_filepath, sizeof(smk_filepath)); // Linux: SMK_Open() fopen()s directly; match the .smk file regardless of case.
+#endif
 	Com_Printf("Opening cinematic file: '%s'...\n", smk_filepath);
 
 	if (!SMK_Open(smk_filepath))

--- a/src/quake2/src/cs_shared/common.c
+++ b/src/quake2/src/cs_shared/common.c
@@ -651,11 +651,22 @@ void Qcommon_Init(const int argc, char** argv)
 	{
 		// If the user didn't give any commands, run default action.
 		if ((int)dedicated->value)
+		{
 			Cbuf_AddText("dedicated_start\n");
+			Cbuf_Execute();
+		}
 		else
-			Cbuf_AddText("demo_loop\n"); // Q2: "d1\n"
-
-		Cbuf_Execute();
+		{
+			// Linux port: the original runs the demo_loop alias here via an immediate
+			// Cbuf_Execute(). That starts a (cinematic) server whose client-side playback
+			// needs the server->client round-trip which only happens inside Qcommon_Frame
+			// (Cbuf_Execute -> SV_Frame -> CL_Frame), so running it during init races and
+			// intermittently shows a black screen. Queue the expanded command (what the
+			// demo_loop alias resolves to in Default.cfg) WITHOUT executing, so it runs in
+			// the first frame exactly like a +command-line command -- which is reliable.
+			// (Deferring the bare alias does not work; it must be the expanded command.)
+			Cbuf_AddText("map bumper.smk@menu_main\n");
+		}
 	}
 	else
 	{

--- a/src/ref_gl1/src/Hunk.c
+++ b/src/ref_gl1/src/Hunk.c
@@ -4,7 +4,11 @@
 // Copyright 1998 Raven Software
 //
 
+#ifdef _WIN32
 #include <windows.h>
+#else
+#include <sys/mman.h>
+#endif
 #include "Hunk.h"
 #include "gl1_Local.h"
 
@@ -22,9 +26,16 @@ void* Hunk_Begin(const int maxsize)
 	hunkmaxsize = maxsize + sizeof(uint) + 32;
 	cursize = 0;
 
+#ifdef _WIN32
 	membase = VirtualAlloc(NULL, maxsize, MEM_RESERVE, PAGE_NOACCESS);
+#else
+	// Reserve the whole region up front; pages are committed lazily on first touch.
+	membase = mmap(NULL, hunkmaxsize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (membase == MAP_FAILED)
+		membase = NULL;
+#endif
 	if (membase == NULL)
-		ri.Sys_Error(ERR_DROP, "VirtualAlloc reserve failed"); //mxd. Sys_Error() -> ri.Sys_Error().
+		ri.Sys_Error(ERR_DROP, "Hunk reserve failed"); //mxd. Sys_Error() -> ri.Sys_Error().
 
 	return membase;
 }
@@ -35,6 +46,7 @@ void* Hunk_Alloc(int size)
 	// Round to cacheline.
 	size = (size + 31) & ~31;
 
+#ifdef _WIN32
 	// Commit pages as needed.
 	void* buf = VirtualAlloc(membase, cursize + size, MEM_COMMIT, PAGE_READWRITE);
 
@@ -43,6 +55,7 @@ void* Hunk_Alloc(int size)
 		FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM, NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&buf, 0, NULL);
 		ri.Sys_Error(ERR_DROP, "VirtualAlloc commit failed.\n%s", buf); //mxd. Sys_Error() -> ri.Sys_Error().
 	}
+#endif
 
 	cursize += size;
 
@@ -63,7 +76,11 @@ int Hunk_End(void)
 void Hunk_Free(void* buf)
 {
 	if (buf != NULL)
+#ifdef _WIN32
 		VirtualFree(buf, 0, MEM_RELEASE);
+#else
+		munmap(buf, hunkmaxsize);
+#endif
 
 	hunkcount--;
 }

--- a/src/ref_gl1/src/gl1_FindSurface.h
+++ b/src/ref_gl1/src/gl1_FindSurface.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+struct Surface_s; // Linux port: file-scope forward decl for GCC tag scoping.
+
 #include "gl1_Local.h"
 
 extern int RI_FindSurface(const vec3_t start, const vec3_t end, struct Surface_s* surface);

--- a/src/ref_gl1/src/gl1_FlexModel.c
+++ b/src/ref_gl1/src/gl1_FlexModel.c
@@ -721,8 +721,8 @@ void R_DrawFlexModel(entity_t* e)
 	{
 		for (int i = 0; i < 3; i++)
 		{
-			const int ñ = (int)(shadelight[i] * 255.0f);
-			shadelight[i] = (float)minlight[min(255, ñ)] / 255.0f;
+			const int nq = (int)(shadelight[i] * 255.0f);
+			shadelight[i] = (float)minlight[min(255, nq)] / 255.0f;
 		}
 	}
 

--- a/src/ref_gl1/src/gl1_FlexModel.h
+++ b/src/ref_gl1/src/gl1_FlexModel.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+struct Surface_s; // Linux port: file-scope forward decl for GCC tag scoping.
+
 #include "gl1_Local.h"
 #include "FlexModel.h"
 #include "Reference.h"

--- a/src/ref_gl1/src/gl1_Model.c
+++ b/src/ref_gl1/src/gl1_Model.c
@@ -819,6 +819,18 @@ void RI_BeginRegistration(const char* model)
 	r_worldmodel = Mod_ForName(fullname, true);
 	r_viewcluster = -1;
 
+	// Mark the world model and its textures as used in this registration sequence
+	// BEFORE freeing unused images. On a same-map reload (savegame load, or re-issuing
+	// the same map) Mod_ForName returns the *cached* world model without refreshing the
+	// texture registration sequence, so R_FreeUnusedImages() below would otherwise free
+	// the world's textures (deleting their GL textures and recycling their image slots),
+	// leaving texinfo pointing at the wrong textures -> progressively corrupted surfaces
+	// on every reload. // Linux port
+	r_worldmodel->registration_sequence = registration_sequence;
+	if (r_worldmodel->type == mod_brush)
+		for (int i = 0; i < r_worldmodel->numtexinfo; i++)
+			r_worldmodel->texinfo[i].image->registration_sequence = registration_sequence;
+
 	R_FreeUnusedImages(); // H2
 }
 

--- a/src/ref_gl1/src/gl1_SDL.c
+++ b/src/ref_gl1/src/gl1_SDL.c
@@ -106,6 +106,10 @@ void RI_ShutdownContext(void)
 {
 	if (window != NULL && context != NULL)
 	{
+		// Release the context from the current thread before destroying it. Destroying
+		// a still-current context crashes inside Mesa's threaded-GL teardown on Linux
+		// (e.g. during vid_restart). // Linux port
+		SDL_GL_MakeCurrent(window, NULL);
 		SDL_GL_DestroyContext(context);
 		context = NULL;
 	}

--- a/src/snd_sdl3/src/snd_ogg.c
+++ b/src/snd_sdl3/src/snd_ogg.c
@@ -89,6 +89,9 @@ void OGG_PlayTrack(const int track, const uint track_pos, const qboolean looping
 	// Open ogg vorbis file.
 	char track_path[MAX_OSPATH];
 	sprintf_s(track_path, sizeof(track_path), "%s/music/Track%02i.ogg", si.FS_Gamedir(), track);
+#ifndef _WIN32
+	H2_ResolveCasePath(track_path, track_path, sizeof(track_path)); // Linux: match Track*.ogg regardless of case.
+#endif
 
 	int vorbis_error = VORBIS__no_error;
 	ogg_file = stb_vorbis_open_filename(track_path, &vorbis_error, NULL);

--- a/src/snd_sdl3/src/snd_sdl3.c
+++ b/src/snd_sdl3/src/snd_sdl3.c
@@ -687,45 +687,43 @@ void SNDSDL3_Update(void)
 // Callback function for SDL. Writes sound data to SDL when requested.
 static void SNDSDL3_FillSDL3AudioBuffer(byte* sdl_stream, const int length)
 {
-	int pos = playpos * (sound.samplebits / 8);
-
-	if (pos >= samplesize)
+	// This runs on SDL's audio thread, unsynchronized with the main thread. If the
+	// mixer isn't in a usable state (e.g. the buffer is being (re)allocated during a
+	// sound/video restart), output silence rather than dereferencing a NULL buffer or
+	// dividing by a zero sample size. // Linux port
+	if (sound.buffer == NULL || sound.samplebits < 8 || samplesize <= 0)
 	{
-		playpos = 0;
-		pos = 0;
+		memset(sdl_stream, 0, length);
+		return;
 	}
 
-	const int to_buffer_end = samplesize - pos;
+	// Copy from the ring buffer in wrapping chunks. The original code did a single
+	// wrap, which read past the buffer when SDL requested more than samplesize bytes
+	// at once (it does this to catch up after the callback is starved during a slow
+	// operation like vid_restart). Loop instead so we never overrun. // Linux port
+	const int width = sound.samplebits / 8;
+	int written = 0;
 
-	int length1;
-	int length2;
-
-	if (length > to_buffer_end)
+	while (written < length)
 	{
-		length1 = to_buffer_end;
-		length2 = length - length1;
-	}
-	else
-	{
-		length1 = length;
-		length2 = 0;
-	}
+		int pos = playpos * width;
+		if (pos >= samplesize)
+		{
+			playpos = 0;
+			pos = 0;
+		}
 
-	memcpy(sdl_stream, sound.buffer + pos, length1);
+		int chunk = samplesize - pos;
+		if (chunk > length - written)
+			chunk = length - written;
 
-	// Set new position.
-	if (length2 <= 0)
-	{
-		playpos += (length1 / (sound.samplebits / 8));
-	}
-	else
-	{
-		memcpy(sdl_stream + length1, sound.buffer, length2);
-		playpos = length2 / (sound.samplebits / 8);
-	}
+		memcpy(sdl_stream + written, sound.buffer + pos, chunk);
+		written += chunk;
 
-	if (playpos >= samplesize)
-		playpos = 0;
+		playpos += chunk / width;
+		if (playpos * width >= samplesize)
+			playpos = 0;
+	}
 }
 
 // Wrapper function, ties the old existing callback logic from the SDL 1.2 days and later fiddled into SDL 2 to a SDL 3 compatible callback...

--- a/src/win32_cross_compat.h
+++ b/src/win32_cross_compat.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#ifdef _WIN32
+#ifndef _MSC_VER // MinGW
+
+#define _WIN32_WINNT 0x0601
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+#include <mmsystem.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+
+// MSVC keywords / calling conventions
+#ifndef _inline
+#define _inline static inline
+#endif
+#ifndef __inline
+#define __inline static inline
+#endif
+
+#ifndef __cplusplus
+#ifndef min
+#define min(a,b) (((a) < (b)) ? (a) : (b))
+#endif
+#ifndef max
+#define max(a,b) (((a) > (b)) ? (a) : (b))
+#endif
+#endif
+
+// Secure CRT stubs for MinGW
+#ifndef fread_s
+#define fread_s(buf, bsz, esz, cnt, fp) fread((buf), (esz), (cnt), (fp))
+#endif
+
+// MinGW doesn't have VersionHelpers.h sometimes or we want to avoid it
+#ifndef IsWindows7OrGreater
+#define IsWindows7OrGreater() 1
+#endif
+
+#endif // !_MSC_VER
+#endif // _WIN32


### PR DESCRIPTION
# Linux port

Adds a Linux build of Heretic2R and fixes the runtime bugs found getting it to run.
The engine, launcher, and all game-side modules build with CMake/GCC and load as ELF
shared objects via `dlopen()`. The game boots, shows the menu, plays the intro/splash
videos, loads levels, renders (ref_gl1/OpenGL), saves/loads, and plays sound + OGG music.

See `BUILDING-linux.md` for build instructions and the full rationale.

## Build system & platform layer (`src/linux/`)
- `CMakeLists.txt` mirroring the 8-module MSVC solution layout.
- `linux_compat.h`: force-included Win32/MSVC shim (secure-CRT `*_s` functions with C++
  array overloads, `min`/`max`, `HINSTANCE`/`DWORD`, `LoadLibrary`→`dlopen`, `__declspec`,
  case-insensitive path resolver, …) plus stub `<windows.h>`/`<direct.h>`/`<io.h>`.
- `sys_unix.c` / `q_shunix.c` / `net_udp.c` / `launcher_main.c`: system layer, main loop,
  filesystem/time helpers (`opendir`/`fnmatch`), BSD-sockets UDP, and the `main()` entry
  (replacing the Win32 `WinMain` / `net_wins` / `q_shwin` / `sys_win`).
- `gen-case-symlinks.py`: regenerates case-correct header symlinks (Linux is
  case-sensitive; not committed since git symlinks misbehave on Windows).

## Commits
1. **Add Linux port** — build system, platform layer, and the compile/link-time fixes
   (mmap Hunk, ELF ctor DllMain, `RTLD_NODELETE`, `SLL_NODE_SIZE`, `va_arg` UB, enum/tag
   scoping, `BUILDSTRING`/`CPUSTRING`, stray non-ASCII identifier, in-initializer
   `#pragma region`, C++ scripting subsystem compiled into gamex86).
2. **Fix savegame load crash on 64-bit** — `F_CLEAR` zeroed only the low 4 bytes of an
   8-byte pointer field.
3. **Fix progressive texture corruption on level reload** — `R_FreeUnusedImages()` freed
   the world's textures on a cached same-map reload.
4. **Show the startup splash/menu reliably** — defer the demo_loop cinematic to the frame
   loop instead of an immediate `Cbuf_Execute()` during init.
5. **Stop the main loop busy-waiting a full CPU core** — sleep instead of spin.
6. **Open game data (.smk / OGG) case-insensitively** — Windows-cased data on Linux.
7. **Fix audio buffer overrun when the SDL callback is starved** — wrapping chunk copy.
8. **Release the GL context from the thread before destroying it** — correct teardown order.

## Notes / known limitations
- 64-bit build (the original is 32-bit x86). Module struct layouts are internally
  consistent; the fixes above resolve the pointer-size assumptions hit at runtime.
- IPX networking dropped (dead protocol).
- `vid_restart` (changing video settings) can still crash inside Mesa's GL-context
  teardown on some drivers — an Mesa-internal issue, not in the game code; normal play is
  unaffected.
- Tested with GCC 14, SDL 3.4.2, Mesa, X11.
