### PR TITLE
Cross platform fixes

### DIFF
--- a/src/quake2/src/win32/sys_win.c
+++ b/src/quake2/src/win32/sys_win.c
@@ -270,18 +270,22 @@ Q2DLL_DECLSPEC int Quake2Main(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPST
 	// The main game loop.
 	while (true)
 	{
-		//TODO: use Sys_Nanosleep(5000) instead of busywait logic when game window is unfocused or minimized?
-		const long long spintime = Sys_Microseconds();
-
-		// YQ2 busywait logic.
-		while (Sys_Microseconds() - spintime < 5)
-			Sys_CpuPause(); // Give the CPU a hint that this is a very tight spinloop.
-
 		const long long newtime = Sys_Microseconds();
+		const long long dt = newtime - oldtime;
+
+		// Cap the loop to ~1 kHz instead of busy-spinning a full CPU core. Qcommon_Frame
+		// applies its own (vid_maxfps) frame limiting, so calling it at 1 kHz is enough;
+		// sleep the remainder of the 1 ms tick when we're ahead of schedule.
+		if (dt < 1000)
+		{
+			Sys_Nanosleep((int)((1000 - dt) * 1000ll)); // microseconds -> nanoseconds
+			continue;
+		}
+
 		curtime = (int)(newtime / 1000ll); // Save global time for network and input code.
 
 		// Missing in H2: _controlfp( _PC_24, _MCW_PC );
-		Qcommon_Frame((int)(newtime - oldtime));
+		Qcommon_Frame((int)dt);
 		oldtime = newtime;
 	}
 

--- a/src/ref_gl1/src/gl1_Model.c
+++ b/src/ref_gl1/src/gl1_Model.c
@@ -819,6 +819,18 @@ void RI_BeginRegistration(const char* model)
 	r_worldmodel = Mod_ForName(fullname, true);
 	r_viewcluster = -1;
 
+	// Mark the world model and its textures as used in this registration sequence
+	// BEFORE freeing unused images. On a same-map reload (savegame load, or re-issuing
+	// the same map) Mod_ForName returns the *cached* world model without refreshing the
+	// texture registration sequence, so R_FreeUnusedImages() below would otherwise free
+	// the world's textures (deleting their GL textures and recycling their image slots),
+	// leaving texinfo pointing at the wrong textures -> progressively corrupted surfaces
+	// on every reload.
+	r_worldmodel->registration_sequence = registration_sequence;
+	if (r_worldmodel->type == mod_brush)
+		for (int i = 0; i < r_worldmodel->numtexinfo; i++)
+			r_worldmodel->texinfo[i].image->registration_sequence = registration_sequence;
+
 	R_FreeUnusedImages(); // H2
 }
 

--- a/src/snd_sdl3/src/snd_sdl3.c
+++ b/src/snd_sdl3/src/snd_sdl3.c
@@ -687,45 +687,43 @@ void SNDSDL3_Update(void)
 // Callback function for SDL. Writes sound data to SDL when requested.
 static void SNDSDL3_FillSDL3AudioBuffer(byte* sdl_stream, const int length)
 {
-	int pos = playpos * (sound.samplebits / 8);
-
-	if (pos >= samplesize)
+	// This runs on SDL's audio thread, unsynchronized with the main thread. If the
+	// mixer isn't in a usable state (e.g. the buffer is being (re)allocated during a
+	// sound/video restart), output silence rather than dereferencing a NULL buffer or
+	// dividing by a zero sample size.
+	if (sound.buffer == NULL || sound.samplebits < 8 || samplesize <= 0)
 	{
-		playpos = 0;
-		pos = 0;
+		memset(sdl_stream, 0, length);
+		return;
 	}
 
-	const int to_buffer_end = samplesize - pos;
+	// Copy from the ring buffer in wrapping chunks. The original code did a single
+	// wrap, which read past the buffer when SDL requested more than samplesize bytes
+	// at once (it does this to catch up after the callback is starved during a slow
+	// operation like vid_restart). Loop instead so we never overrun.
+	const int width = sound.samplebits / 8;
+	int written = 0;
 
-	int length1;
-	int length2;
-
-	if (length > to_buffer_end)
+	while (written < length)
 	{
-		length1 = to_buffer_end;
-		length2 = length - length1;
-	}
-	else
-	{
-		length1 = length;
-		length2 = 0;
-	}
+		int pos = playpos * width;
+		if (pos >= samplesize)
+		{
+			playpos = 0;
+			pos = 0;
+		}
 
-	memcpy(sdl_stream, sound.buffer + pos, length1);
+		int chunk = samplesize - pos;
+		if (chunk > length - written)
+			chunk = length - written;
 
-	// Set new position.
-	if (length2 <= 0)
-	{
-		playpos += (length1 / (sound.samplebits / 8));
-	}
-	else
-	{
-		memcpy(sdl_stream + length1, sound.buffer, length2);
-		playpos = length2 / (sound.samplebits / 8);
-	}
+		memcpy(sdl_stream + written, sound.buffer + pos, chunk);
+		written += chunk;
 
-	if (playpos >= samplesize)
-		playpos = 0;
+		playpos += chunk / width;
+		if (playpos * width >= samplesize)
+			playpos = 0;
+	}
 }
 
 // Wrapper function, ties the old existing callback logic from the SDL 1.2 days and later fiddled into SDL 2 to a SDL 3 compatible callback...


### PR DESCRIPTION
Three small, platform-independent fixes found while getting Heretic2R running on
Linux. They're in shared code (or, for the CPU one, the Win32 main loop), so they
apply to the Windows build too. Each is an isolated, single-file commit.

### 1. Progressive texture corruption on level reload (gl1_Model.c)
RI_BeginRegistration() calls the H2-added R_FreeUnusedImages() after loading the
world model. On a *same-map* reload (loading a savegame, or re-issuing the same map),
Mod_ForName() returns the cached world model without refreshing its textures'
registration sequence — so R_FreeUnusedImages() frees them, deleting their GL textures
and recycling the image slots for other models. The cached world's texinfo then points
at the wrong textures, and surfaces render garbage that worsens with each reload
(e.g. die → load savegame). Fix: mark the world model + its texinfo images as in-use
before freeing.

### 2. Audio buffer overrun when the SDL callback is starved (snd_sdl3.c)
SNDSDL3_FillSDL3AudioBuffer assumed the request fit the mixer ring buffer and did a
single wrap. SDL can ask for more than samplesize at once to catch up after the
callback is starved (e.g. a slow main-thread operation), making the wrap-around memcpy
read past the buffer and crash. Fix: copy in wrapping chunks (handles any size), and
output silence if the mixer state isn't ready.

### 3. Main loop busy-waits a full CPU core (sys_win.c)
The YQ2 main loop busy-spins with Sys_CpuPause(), pinning a core at ~100% even when
idle. Cap to ~1 kHz by sleeping the remainder of each 1 ms tick (Sys_Nanosleep);
Qcommon_Frame already does its own vid_maxfps limiting.

**Testing:** #1 and #2 were verified on Linux (same shared code). #3 I could only
validate on the Linux equivalent — I don't have an MSVC/Windows build environment, so
please sanity-check the Windows frame timing.